### PR TITLE
Fix cover responsive layout: correct grid-column/row overrides

### DIFF
--- a/src/pages/_components/Bento/styles.module.css
+++ b/src/pages/_components/Bento/styles.module.css
@@ -361,7 +361,7 @@
     gap: 0.75rem;
   }
 
-  .cardMain {
+  .cardMainLink {
     grid-column: span 2;
     grid-row: span 1;
   }
@@ -377,6 +377,15 @@
 
   .name {
     font-size: 1.5rem;
+  }
+
+  .nameRow {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .statusInline {
+    margin-left: 0;
   }
 
   .cardSocial {
@@ -410,11 +419,12 @@
     grid-template-columns: 1fr;
   }
 
-  .cardMain,
+  .cardMainLink,
   .cardSocial,
   .cardLatestPost,
   .cardNav {
     grid-column: span 1;
+    grid-row: span 1;
   }
 
   .cardNavArrow {


### PR DESCRIPTION
- Add `.cardMainLink { grid-column: span 1; grid-row: span 1 }` to the ≤440px breakpoint; the missing override forced an implicit second column in a 1fr grid, causing the profile card to overflow to 446px and all right-column items to fall off-screen on mobile.
- Fix ≤768px media query targeting `.cardMain` (inner element, not a grid item) → now correctly targets `.cardMainLink` with `grid-row: span 1` so the profile card does not reserve two rows at tablet size.
- Allow `.nameRow` to wrap and reset `margin-left` on `.statusInline` at ≤768px so the "Available" badge is never clipped on narrow screens.