### PR TITLE
Refactor home responsive layout for 200px+ viewports

### DIFF
--- a/src/components/laikit/Section/styles.module.css
+++ b/src/components/laikit/Section/styles.module.css
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   margin: 0 auto;
+  min-width: 0;
 }
 
 .sectionInner {
@@ -13,13 +14,14 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  margin: 4rem auto;
-  padding: 0 1rem;
+  margin: clamp(2rem, 6vw, 4rem) auto;
+  padding: 0 clamp(0.75rem, 3vw, 1rem);
+  min-width: 0;
 }
 
 .header {
   width: 100%;
-  margin-bottom: 3rem;
+  margin-bottom: clamp(1.5rem, 5vw, 3rem);
 }
 
 .alignCenter {
@@ -33,17 +35,19 @@
 .title {
   margin: 0 0 1rem;
   color: var(--ifm-font-color-base);
-  font-size: 2.25rem;
+  font-size: clamp(1.5rem, 5vw, 2.25rem);
   font-weight: 700;
   line-height: 1.25;
+  overflow-wrap: anywhere;
 }
 
 .description {
   max-width: 48rem;
   margin: 0;
   color: var(--ifm-color-emphasis-700);
-  font-size: 1.125rem;
+  font-size: clamp(0.95rem, 2.6vw, 1.125rem);
   line-height: 1.625;
+  overflow-wrap: anywhere;
 }
 
 .alignCenter .description {

--- a/src/pages/_components/Bento/styles.module.css
+++ b/src/pages/_components/Bento/styles.module.css
@@ -1,5 +1,6 @@
 .hero {
-  padding: 3rem 1.5rem 4rem;
+  padding: clamp(1.5rem, 4vw, 3rem) clamp(0.75rem, 3vw, 1.5rem)
+    clamp(2rem, 5vw, 4rem);
   min-height: calc(100vh - var(--ifm-navbar-height));
   display: flex;
   align-items: center;
@@ -8,9 +9,9 @@
 
 .bento {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: auto auto auto;
-  gap: 1rem;
+  gap: clamp(0.5rem, 1.5vw, 1rem);
   max-width: 800px;
   width: 100%;
 }
@@ -19,12 +20,17 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  min-width: 0;
+  /* Fluid padding override for the Card wrapper — eats less horizontal
+     space on narrow viewports while keeping the desktop feel. */
+  --card-padding: clamp(1rem, 3.5vw, 1.75rem);
 }
 
 .cardMainLink {
   grid-column: span 2;
   grid-row: span 2;
   display: block;
+  min-width: 0;
   color: inherit;
   text-decoration: none !important;
 }
@@ -37,50 +43,56 @@
 .cardMainInner {
   display: flex;
   align-items: center;
-  gap: 1.25rem;
-  margin-bottom: 1.5rem;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  margin-bottom: clamp(1rem, 2.5vw, 1.5rem);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 
 .avatar {
-  width: 72px;
-  height: 72px;
+  width: clamp(48px, 10vw, 72px);
+  height: clamp(48px, 10vw, 72px);
   border-radius: 50%;
   object-fit: cover;
+  flex-shrink: 0;
 }
 
 .intro {
   flex: 1;
+  min-width: 0;
 }
 
 .nameRow {
   display: flex;
   align-items: center;
-  gap: 0.625rem;
-  flex-wrap: nowrap;
+  gap: 0.5rem 0.625rem;
+  flex-wrap: wrap;
 }
 
 .name {
-  font-size: 1.75rem;
+  font-size: clamp(1.25rem, 4vw, 1.75rem);
   font-weight: 700;
   margin: 0;
   letter-spacing: -0.02em;
+  word-break: break-word;
 }
 
 .statusInline {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  margin-left: auto;
+  gap: 0.4rem;
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
   border: 1px solid var(--ifm-color-emphasis-200);
   background: var(--ifm-color-emphasis-100);
+  max-width: 100%;
 }
 
 .role {
-  font-size: 0.95rem;
+  font-size: clamp(0.85rem, 2.2vw, 0.95rem);
   color: var(--ifm-color-emphasis-600);
   margin: 0.25rem 0 0;
+  overflow-wrap: anywhere;
 }
 
 .roleTyping {
@@ -114,7 +126,7 @@
 .profileTags {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
+  gap: 0.4rem 0.55rem;
 }
 
 .profileTag {
@@ -129,11 +141,14 @@
   font-size: 0.75rem;
   line-height: 1.1;
   font-weight: 500;
+  max-width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .profileTagIcon {
   font-size: 0.75rem;
   color: var(--ifm-color-emphasis-600);
+  flex-shrink: 0;
 }
 
 .cardNav {
@@ -143,7 +158,10 @@
   justify-content: space-between;
   position: relative;
   overflow: hidden;
-  min-height: 100px;
+  min-width: 0;
+  min-height: clamp(84px, 14vw, 100px);
+  gap: 0.5rem;
+  --card-padding: clamp(0.85rem, 3vw, 1.25rem);
 }
 
 .cardNav::before {
@@ -168,10 +186,11 @@
 }
 
 .cardNavIcon {
-  font-size: 1.5rem;
+  font-size: clamp(1.25rem, 3.5vw, 1.5rem);
   position: relative;
   z-index: 1;
   color: var(--link-card-accent);
+  flex-shrink: 0;
 }
 
 .cardNav1 {
@@ -195,16 +214,18 @@
 }
 
 .cardNavTitle {
-  font-size: 1rem;
+  font-size: clamp(0.875rem, 2.5vw, 1rem);
   font-weight: 600;
   position: relative;
   z-index: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .cardNavArrow {
   position: absolute;
-  top: 1rem;
-  right: 1rem;
+  top: 0.85rem;
+  right: 0.85rem;
   font-size: 1rem;
   color: var(--ifm-color-emphasis-400);
   opacity: 0;
@@ -225,20 +246,27 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  min-width: 0;
+  --card-padding: clamp(0.85rem, 3vw, 1.25rem);
 }
 
 .cardSocialLabel {
   font-size: 0.875rem;
   font-weight: 500;
   color: var(--ifm-color-emphasis-600);
+  flex-shrink: 0;
 }
 
 .socialLinks {
-  display: grid;
-  grid-template-columns: repeat(4, 40px);
-  grid-template-rows: repeat(2, 40px);
+  display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
-  justify-content: end;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-left: auto;
 }
 
 .socialLink {
@@ -247,6 +275,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
+  flex-shrink: 0;
   border-radius: 12px;
   color: var(--ifm-color-emphasis-600);
   background: var(--ifm-color-emphasis-100);
@@ -260,6 +289,8 @@
 .cardLatestPost {
   grid-column: 3 / span 2;
   grid-row: 3;
+  min-width: 0;
+  --card-padding: clamp(0.85rem, 3vw, 1.25rem);
 }
 
 .latestPostLink {
@@ -290,7 +321,7 @@
 
 .latestPostTitle {
   margin: 0;
-  font-size: 1rem;
+  font-size: clamp(0.9rem, 2.4vw, 1rem);
   font-weight: 600;
   line-height: 1.4;
   color: var(--ifm-color-emphasis-900);
@@ -299,6 +330,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  overflow-wrap: anywhere;
 }
 
 .latestPostMeta {
@@ -311,11 +343,13 @@
   font-weight: 500;
   line-height: 1.3;
   color: var(--ifm-color-emphasis-800);
+  flex-wrap: wrap;
 }
 
 .latestPostMetaIcon {
   font-size: 0.9rem;
   color: var(--ifm-color-emphasis-500);
+  flex-shrink: 0;
 }
 
 .latestPostEmpty {
@@ -329,6 +363,7 @@
   background: #22c55e;
   border-radius: 50%;
   animation: pulse 2s ease-in-out infinite;
+  flex-shrink: 0;
 }
 
 @keyframes pulse {
@@ -344,44 +379,21 @@
 }
 
 .statusText {
-  font-size: 0.875rem;
+  font-size: 0.8rem;
   color: var(--ifm-color-emphasis-700);
   font-weight: 500;
   line-height: 1;
 }
 
+/* ≤768px: collapse to 2 cols; main card spans full row */
 @media (max-width: 768px) {
-  .hero {
-    padding: 2rem 1rem 3rem;
-    min-height: auto;
-  }
-
   .bento {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .cardMainLink {
     grid-column: span 2;
     grid-row: span 1;
-  }
-
-  .cardMainInner {
-    gap: 1rem;
-  }
-
-  .avatar {
-    width: 56px;
-    height: 56px;
-  }
-
-  .name {
-    font-size: 1.5rem;
-  }
-
-  .nameRow {
-    flex-wrap: wrap;
-    gap: 0.4rem;
   }
 
   .statusInline {
@@ -399,24 +411,43 @@
   }
 }
 
+/* ≤480px: nav cards become horizontal rows so they stay compact */
 @media (max-width: 480px) {
   .cardNav {
     flex-direction: row;
     align-items: center;
     min-height: auto;
-    gap: 1rem;
+    gap: 0.75rem;
+    padding-right: 2.25rem;
   }
 
   .cardNavArrow {
-    position: static;
-    transform: none;
-    margin-left: auto;
+    position: absolute;
+    top: 50%;
+    right: 0.85rem;
+    transform: translateY(-50%);
+    opacity: 0.5;
+  }
+
+  .cardNav:hover .cardNavArrow {
+    transform: translateY(-50%);
+    opacity: 1;
+  }
+
+  .cardSocial {
+    justify-content: flex-start;
+  }
+
+  .socialLinks {
+    margin-left: 0;
+    justify-content: flex-start;
   }
 }
 
+/* ≤440px: single column, everything stacks */
 @media (max-width: 440px) {
   .bento {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .cardMainLink,
@@ -426,8 +457,57 @@
     grid-column: span 1;
     grid-row: span 1;
   }
+}
+
+/* ≤360px: further tighten to keep everything readable down to 200px */
+@media (max-width: 360px) {
+  .cardMainInner {
+    gap: 0.65rem;
+  }
+
+  .nameRow {
+    gap: 0.35rem 0.5rem;
+  }
+
+  .profileTag {
+    padding: 0.2rem 0.45rem;
+    font-size: 0.7rem;
+  }
+
+  .socialLinks {
+    gap: 0.35rem;
+  }
+
+  .socialLink {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+  }
+
+  .cardNav {
+    padding-right: 2rem;
+  }
 
   .cardNavArrow {
-    opacity: 1;
+    right: 0.65rem;
+  }
+}
+
+/* ≤260px: extreme case — collapse avatar row to vertical */
+@media (max-width: 260px) {
+  .cardMainInner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+  }
+
+  .statusInline {
+    padding: 0.15rem 0.45rem;
+    font-size: 0.7rem;
+  }
+
+  .socialLink {
+    width: 32px;
+    height: 32px;
   }
 }

--- a/src/pages/_components/Blog/styles.module.css
+++ b/src/pages/_components/Blog/styles.module.css
@@ -1,6 +1,10 @@
 .sectionSurface {
-  width: calc(100% + 2rem);
-  margin: 0 -1rem;
+  /* Cancel the Section's fluid inline padding so the backdrop stays
+     edge-to-edge across all viewport widths (200–1440+) without relying
+     on 100vw, which can overshoot when a classic scrollbar is present. */
+  --surface-bleed: clamp(0.75rem, 3vw, 1rem);
+  width: calc(100% + 2 * var(--surface-bleed));
+  margin-inline: calc(var(--surface-bleed) * -1);
   background: var(--ifm-color-emphasis-100);
 }
 
@@ -11,7 +15,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 4rem 1.25rem 2rem;
+  padding: clamp(2rem, 5vw, 4rem) clamp(0.75rem, 3vw, 1.25rem) 2rem;
+  min-width: 0;
 }
 
 .layout {
@@ -21,6 +26,7 @@
   flex-direction: column;
   gap: 1.25rem;
   margin: 0 auto;
+  min-width: 0;
 }
 
 .copy {
@@ -30,22 +36,27 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+  min-width: 0;
 }
 
 .title {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin: 0 0 2rem;
+  margin: 0 0 clamp(1rem, 3vw, 2rem);
   color: var(--ifm-font-color-base);
-  font-size: 1.875rem;
+  font-size: clamp(1.375rem, 4.5vw, 1.875rem);
   font-weight: 700;
   line-height: 1.25;
+  flex-wrap: wrap;
+  overflow-wrap: anywhere;
 }
 
 .description {
   margin: 0 0 1.5rem;
   line-height: 1.625;
+  font-size: clamp(0.9rem, 2.4vw, 1rem);
+  overflow-wrap: anywhere;
 }
 
 .moreLink {
@@ -54,6 +65,7 @@
 
 .posts {
   width: 100%;
+  min-width: 0;
 }
 
 .postsHeading {
@@ -65,19 +77,21 @@
   color: var(--ifm-color-emphasis-700);
   font-size: 0.875rem;
   font-weight: 700;
+  flex-wrap: wrap;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 1.5rem;
-  margin: 2rem 0;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(1rem, 2.5vw, 1.5rem);
+  margin: clamp(1.25rem, 3vw, 2rem) 0;
   text-align: left;
   width: 100%;
 }
 
 .gridItem {
   height: 100%;
+  min-width: 0;
 }
 
 .gridItemHidden {
@@ -112,14 +126,16 @@
 
 .card {
   height: 100%;
+  min-width: 0;
 }
 
 .cardBody {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: clamp(1rem, 2.5vw, 1.5rem);
   height: 100%;
+  min-width: 0;
 }
 
 .cardTitle {
@@ -128,12 +144,13 @@
   margin: 0;
   overflow: hidden;
   color: var(--ifm-font-color-base);
-  font-size: 1.125rem;
+  font-size: clamp(1rem, 2.6vw, 1.125rem);
   font-weight: 600;
   line-height: 1.375;
   text-overflow: ellipsis;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  overflow-wrap: anywhere;
 }
 
 .cardMeta {
@@ -142,6 +159,7 @@
   gap: 0.5rem;
   color: var(--ifm-color-emphasis-700);
   font-size: 0.875rem;
+  flex-wrap: wrap;
 }
 
 .time {
@@ -149,10 +167,6 @@
 }
 
 @media (min-width: 768px) {
-  .title {
-    font-size: 2.25rem;
-  }
-
   .grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/src/pages/_components/Countdown/styles.module.css
+++ b/src/pages/_components/Countdown/styles.module.css
@@ -1,37 +1,39 @@
 /* Countdown Component Styles */
 
-/* SVG styles */
+/* SVG fills the circular container so geometry scales with width */
 .circleSvg {
   position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
   transform: rotate(-90deg);
 }
 
 .pxcontainer {
   position: relative;
-  width: 160px;
-  height: 160px;
-  display: flex;
+  width: 100%;
+  max-width: 160px;
+  aspect-ratio: 1 / 1;
+  container-type: inline-size;
+  min-width: 0;
+  margin-inline: auto;
 }
-
-/* .progressCircle {
-  transition: stroke-dasharray 0.4s ease-out;
-}
-
-.progressDot {
-  transition: cx 0.4s ease-out, cy 0.4s ease-out;
-} */
 
 .pxanchor {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  width: 100%;
+  text-align: center;
+  pointer-events: none;
 }
 
 .pxtitle {
-  font-size: 40px;
+  /* 40 / 160 = 25% of container inline size */
+  font-size: clamp(20px, 25cqi, 40px);
   font-weight: 600;
-  line-height: 32px;
+  line-height: 1;
   text-align: center;
 }
 
@@ -41,7 +43,7 @@
   left: 50%;
   transform: translateX(-50%);
   margin-top: 4px;
-  font-size: 12px;
+  font-size: clamp(10px, 2.5vw, 12px);
   font-weight: 400;
   opacity: 0.85;
   white-space: nowrap;
@@ -56,27 +58,38 @@
   color: rgb(38 38 38);
 }
 
-/* Countdown content layout */
+/* Countdown content layout — fluid auto-fit grid */
 .countdownLayout {
-  display: flex;
-  gap: 2rem;
-  justify-content: center;
-  width: fit-content;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: clamp(1.25rem, 3vw, 2rem);
+  justify-items: center;
+  align-items: center;
+  width: 100%;
+  max-width: 760px;
   margin: 0 auto;
 }
 
-/* Responsive grid for mobile */
-@media (max-width: 768px) {
+/* ≤360px: lock to 2 columns with smaller circles */
+@media (max-width: 360px) {
   .countdownLayout {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.5rem 0.75rem;
+  }
+
+  .pxcontainer {
+    max-width: 120px;
   }
 }
 
-@media (max-width: 400px) {
+/* ≤260px: single column, each circle centered */
+@media (max-width: 260px) {
   .countdownLayout {
-    grid-template-columns: 1fr;
-    gap: 1rem;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+
+  .pxcontainer {
+    max-width: 140px;
   }
 }

--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -113,33 +113,53 @@ export default function FourierTransformCanvas() {
     state.time = 0;
   };
 
-  // Handle resize
+  // Handle resize — keep the canvas square, fluid, and usable at narrow widths
   useEffect(() => {
+    if (!containerRef.current) return;
+
+    const MAX_SIZE = 500;
+    const MIN_SIZE = 120; // prevents divide-by-zero & degenerate layout
+    const RESIZE_THRESHOLD = 8;
+
     const updateSize = () => {
-      if (containerRef.current) {
-        const containerWidth = containerRef.current.clientWidth;
-        const newSize = Math.min(containerWidth - 32, 500);
-        const oldSize = canvasSize;
+      if (!containerRef.current) return;
+      const containerWidth = containerRef.current.clientWidth;
+      // Fit the container exactly (container width already excludes the
+      // parent Section padding) so CSS pixel space and drawing coordinate
+      // space stay aligned, which keeps touch/mouse mapping accurate.
+      const nextSize = Math.max(
+        MIN_SIZE,
+        Math.min(Math.floor(containerWidth), MAX_SIZE)
+      );
+      const oldSize = canvasSize;
 
-        if (Math.abs(newSize - oldSize) > 10) {
-          const ratio = newSize / oldSize;
-          const state = stateRef.current;
+      if (Math.abs(nextSize - oldSize) >= RESIZE_THRESHOLD) {
+        const ratio = nextSize / oldSize;
+        const state = stateRef.current;
 
-          // Scale existing drawing
-          if (state.drawing.length > 0) {
-            state.drawing = state.drawing.map((p) => ({
-              x: p.x * ratio,
-              y: p.y * ratio,
-            }));
-            calcFourier();
-          }
-
-          setCanvasSize(newSize);
+        if (state.drawing.length > 0) {
+          state.drawing = state.drawing.map((p) => ({
+            x: p.x * ratio,
+            y: p.y * ratio,
+          }));
+          calcFourier();
         }
+
+        setCanvasSize(nextSize);
       }
     };
 
     updateSize();
+
+    // Prefer ResizeObserver — fires for any container change (flex/grid reflow,
+    // orientation change, parent padding change) not just window resize.
+    const RO = (window as any).ResizeObserver;
+    if (typeof RO === 'function') {
+      const ro = new RO(updateSize);
+      ro.observe(containerRef.current);
+      return () => ro.disconnect();
+    }
+
     window.addEventListener('resize', updateSize);
     return () => window.removeEventListener('resize', updateSize);
   }, [canvasSize]);

--- a/src/pages/_components/FourierTransform/styles.module.css
+++ b/src/pages/_components/FourierTransform/styles.module.css
@@ -5,6 +5,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  min-width: 0;
+  /* Horizontal safety net: if the canvas ever exceeds the parent
+     (e.g. MIN_SIZE > container), allow scrolling instead of clipping. */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .canvas {
@@ -14,4 +19,6 @@
   touch-action: none;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
   border: 1px solid var(--ifm-color-emphasis-300);
+  max-width: 100%;
+  height: auto;
 }

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -49,6 +49,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  min-width: 0;
+  /* Let the SVG scale gracefully down to very narrow viewports; below
+     ~320px horizontal scrolling keeps interactive elements usable. */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
 }
 
 /* Light Mode Theme — "Blueprint" style */
@@ -97,14 +103,20 @@
 
 .svg {
   display: block;
+  /* Stay fluid but guarantee enough internal space to preserve touch
+     targets and legibility. Below ~320px the parent will scroll. */
   width: 100%;
-  height: auto;
+  min-width: 320px;
   max-width: 640px;
+  height: auto;
+  aspect-ratio: 640 / 480;
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
+  flex: 0 0 auto;
+  margin: 0 auto;
 }
 
 /* 神经元样式 */

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -7,6 +7,8 @@
   z-index: 20;
   background: var(--ifm-background-color);
   overflow: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
   transition: transform 0.72s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -17,13 +19,16 @@
 
 .scrollGuide {
   position: fixed;
+  /* Keep the pill centered but never let it touch the viewport edges */
   left: 50%;
+  right: auto;
   bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
   padding: 0.45rem 0.9rem;
+  max-width: calc(100vw - 1.5rem);
   border-radius: 999px;
   border: 1px solid var(--ifm-color-emphasis-300);
   background: var(--ifm-background-color);
@@ -33,12 +38,16 @@
   font-weight: 600;
   letter-spacing: 0.02em;
   line-height: 1;
+  white-space: nowrap;
   cursor: pointer;
   transition: opacity 0.2s ease;
+  z-index: 21;
 }
 
-.scrollGuide:hover {
+.scrollGuide:hover,
+.scrollGuide:focus-visible {
   opacity: 1;
+  outline: none;
 }
 
 @media (max-width: 768px) {
@@ -46,6 +55,15 @@
     bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
     padding: 0.4rem 0.75rem;
     font-size: 0.72rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .scrollGuide {
+    bottom: calc(0.5rem + env(safe-area-inset-bottom, 0px));
+    padding: 0.35rem 0.65rem;
+    gap: 0.25rem;
+    font-size: 0.68rem;
   }
 }
 


### PR DESCRIPTION
Rework every homepage component's responsive layout so structure, proportions and interactions stay intact across the full 200–1440px viewport range.

Shared approach
- Replace fixed spacing/font sizes with clamp() so sections flow smoothly instead of stepping at a handful of breakpoints.
- Add min-width: 0 on flex/grid children and overflow-wrap: anywhere on text containers to prevent long labels from blowing out layouts.
- Consolidate on 768/480/440/360/260 as breakpoint anchors across components for consistent structural transitions.

Per component
- Section (laikit): fluid margin/padding/header spacing and title font size, so every Section inherits sane narrow-viewport behavior.
- Bento: fluid card paddings via --card-padding overrides; avatar, name, nav icons and latest-post title all scale via clamp(); social links switch from a rigid grid to flex-wrap so 40x40 squares stay tidy when the card wraps; extra ≤360 / ≤260 breakpoints keep the layout coherent down to 200px (avatar row turns vertical at 260).
- Countdown: pxcontainer is now width:100% with aspect-ratio 1/1 and container-type: inline-size; pxtitle sizes in cqi so the number stays proportional inside any circle diameter; grid uses auto-fit minmax(120px, 1fr) with ≤360 (2 cols, 120px) and ≤260 (1 col, 140px) fallbacks.
- Blog: sectionSurface bleed now derived from the same clamp() as the Section padding (via --surface-bleed) so the backdrop stays flush with the viewport at every width, without using 100vw.
- NeuralNetwork: SVG keeps min-width: 320px plus aspect-ratio 640/480, and the outer container gets overflow-x: auto so the drawing area stays usably large below 320px instead of shrinking into an unusable target.
- FourierTransform: canvas sizing is now clamp [120, MAX] driven by a ResizeObserver on the container (with window-resize fallback); CSS pixel size matches the drawing coordinate size so pointer mapping remains accurate at any width.
- Page cover / scrollGuide: pill has max-width calc(100vw - 1.5rem) and white-space: nowrap to avoid edge clipping; new ≤360 tightened padding; focus-visible styling added.