### PR TITLE
Refine settings page and add gray mode

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -789,34 +789,37 @@
     "message": "项设置"
   },
   "pages.settings.item.theme.title": {
-    "message": "外观主题"
+    "message": "主题"
   },
   "pages.settings.item.theme.description": {
-    "message": "选择一个适合您的主题模式"
+    "message": "切换浅色、深色或跟随系统"
   },
   "pages.settings.item.color.title": {
-    "message": "主题色生成器"
+    "message": "主题色"
   },
   "pages.settings.item.color.description": {
-    "message": "自定义网站的主色调，实时预览效果"
+    "message": "自定义网站主色调"
+  },
+  "pages.settings.item.color.reset": {
+    "message": "重置"
   },
   "pages.settings.item.font.title": {
     "message": "字体大小"
   },
   "pages.settings.item.font.description": {
-    "message": "调整界面字体以获得最佳阅读体验"
+    "message": "调整界面文字大小"
   },
   "pages.settings.item.experimental.title": {
-    "message": "实验性内容"
+    "message": "实验性功能"
   },
   "pages.settings.item.experimental.description": {
-    "message": "尝试仍在开发的新功能"
+    "message": "试用开发中的新功能"
   },
   "pages.settings.item.quickactions.title": {
     "message": "快捷操作"
   },
   "pages.settings.item.quickactions.description": {
-    "message": "快速管理您的个性化配置"
+    "message": "一键执行常用操作"
   },
   "pages.settings.item.theme.option.system": {
     "message": "系统模式"
@@ -835,6 +838,9 @@
   },
   "pages.settings.item.experimental.option.debugMode": {
     "message": "调试模式"
+  },
+  "pages.settings.item.experimental.option.grayMode": {
+    "message": "灰色模式"
   },
   "pages.settings.item.quickactions.option.confetti": {
     "message": "给我惊喜"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,6 +6,7 @@
   --ifm-color-primary-light: #36a6f2;
   --ifm-color-primary-lighter: #43acf3;
   --ifm-color-primary-lightest: #69bcf5;
+  --ifm-color-primary-rgb: 29, 155, 240;
   --ifm-font-family-base:
     'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont, 'Inter',
     system-ui, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif,

--- a/src/data/changelog.tsx
+++ b/src/data/changelog.tsx
@@ -8,6 +8,11 @@ interface ChangelogItem {
 
 export const CHANGELOG_LIST: ChangelogItem[] = [
   {
+    date: '2026-04-25',
+    type: 'added',
+    content: '网站灰色模式',
+  },
+  {
     date: '2026-04-19',
     type: 'removed',
     content: '<b>Tailwind CSS</b> 依赖',

--- a/src/data/settings.tsx
+++ b/src/data/settings.tsx
@@ -12,4 +12,5 @@ export const SETTINGS_PRESET_COLOR_LIST = [
 export const SETTINGS_EXPERIMENTAL_DEFAULT = {
   originalLayout: false,
   debugMode: false,
+  grayMode: false,
 };

--- a/src/hooks/useGrayMode.ts
+++ b/src/hooks/useGrayMode.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+
+interface ExperimentalSettings {
+  originalLayout: boolean;
+  debugMode: boolean;
+  grayMode: boolean;
+}
+
+export function useGrayMode(): boolean {
+  const [grayMode, setGrayMode] = useState(false);
+
+  useEffect(() => {
+    // 读取localStorage中的灰色模式状态
+    const loadGrayMode = () => {
+      try {
+        const settings = localStorage.getItem('settings-experimental');
+        if (settings) {
+          const parsed: ExperimentalSettings = JSON.parse(settings);
+          setGrayMode(Boolean(parsed.grayMode));
+        }
+      } catch {
+        setGrayMode(false);
+      }
+    };
+
+    // 初始加载
+    loadGrayMode();
+
+    // 监听localStorage变化（跨标签页同步）
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key === 'settings-experimental') {
+        loadGrayMode();
+      }
+    };
+
+    // 监听自定义事件（同一页面内的变化）
+    const handleExperimentalSettingsChange = (e: CustomEvent) => {
+      if (e.detail.key === 'grayMode') {
+        setGrayMode(e.detail.checked);
+      }
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    window.addEventListener(
+      'experimentalSettingsChanged',
+      handleExperimentalSettingsChange as EventListener
+    );
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener(
+        'experimentalSettingsChanged',
+        handleExperimentalSettingsChange as EventListener
+      );
+    };
+  }, []);
+
+  return grayMode;
+}

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -56,11 +56,14 @@ export function useThemeColors(isDarkTheme: boolean) {
   const updateColor = useCallback((colorValue: string) => {
     const newColor = colorValue.replace(/^(?=[^#])/, '#');
     setInputColor(newColor);
+    let hex: string;
     try {
-      setColorState((prev) => ({ ...prev, baseColor: Color(newColor).hex() }));
+      hex = Color(newColor).hex().toLowerCase();
     } catch {
-      // user is still typing an incomplete color string
+      // user is still typing an incomplete or invalid color string
+      return;
     }
+    setColorState((prev) => ({ ...prev, baseColor: hex }));
   }, []);
 
   // 重置到默认颜色

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -6,7 +6,6 @@ import { translate } from '@docusaurus/Translate';
 import Layout from '@theme/Layout';
 
 import Card from '@site/src/components/laikit/Card';
-import IconText from '@site/src/components/laikit/IconText';
 import Switch from '@site/src/components/laikit/Switch';
 import DataCard from '@site/src/components/laikit/DataCard';
 import {
@@ -43,9 +42,11 @@ interface SettingCardProps {
 
 function SettingCard({ title, description, icon, children }: SettingCardProps) {
   return (
-    <Card padding="1.5rem">
+    <Card padding="1.5rem" className={styles.settingCard}>
       <div className={styles.cardHeader}>
-        <Icon icon={icon} className={styles.cardIcon} />
+        <div className={styles.cardIconWrapper}>
+          <Icon icon={icon} className={styles.cardIcon} />
+        </div>
         <div className={styles.cardTitleGroup}>
           <h3 className={styles.cardTitle}>{title}</h3>
           <span className={styles.cardDescription}>{description}</span>
@@ -93,23 +94,24 @@ function ThemeSettings() {
       })}
       description={translate({
         id: 'pages.settings.item.theme.description',
-        message: 'Select a theme mode that suits you',
+        message: 'Switch between light, dark, or system',
       })}
       icon="lucide:monitor"
     >
-      <div className={styles.buttonGroup}>
+      <div className={styles.segmented}>
         {themeOptions.map((option) => (
           <button
-            key={option.key}
+            key={option.key ?? 'system'}
+            type="button"
             className={clsx(
-              styles.button,
-              colorModeChoice === option.key && styles.buttonActive
+              styles.segmentItem,
+              colorModeChoice === option.key && styles.segmentItemActive
             )}
             onClick={() => setColorMode(option.key)}
+            aria-pressed={colorModeChoice === option.key}
           >
-            <IconText icon={option.icon} colorMode="monochrome">
-              {option.label}
-            </IconText>
+            <Icon icon={option.icon} className={styles.segmentIcon} />
+            <span className={styles.segmentLabel}>{option.label}</span>
           </button>
         ))}
       </div>
@@ -117,7 +119,7 @@ function ThemeSettings() {
   );
 }
 
-function ColorGenerator() {
+function AccentColor() {
   const { colorMode } = useColorMode();
   const { colorState, inputColor, updateColor, resetColors } = useThemeColors(
     colorMode === 'dark'
@@ -127,12 +129,11 @@ function ColorGenerator() {
     <SettingCard
       title={translate({
         id: 'pages.settings.item.color.title',
-        message: 'Color Generator',
+        message: 'Accent Color',
       })}
       description={translate({
         id: 'pages.settings.item.color.description',
-        message:
-          'Customize the main color of the website, preview the effect in real time',
+        message: "Customize the site's primary color",
       })}
       icon="lucide:palette"
     >
@@ -176,8 +177,15 @@ function ColorGenerator() {
                 .join(', ')})`,
             }}
           />
-          <button className={styles.resetButton} onClick={resetColors}>
-            <Icon icon="lucide:refresh-ccw" />
+          <button
+            type="button"
+            className={styles.resetButton}
+            onClick={resetColors}
+          >
+            {translate({
+              id: 'pages.settings.item.color.reset',
+              message: 'Reset',
+            })}
           </button>
         </div>
       </div>
@@ -185,7 +193,7 @@ function ColorGenerator() {
   );
 }
 
-function FontSettings() {
+function FontSize() {
   const [fontSize, setFontSize] = useState<number>(16);
 
   useEffect(() => {
@@ -205,6 +213,10 @@ function FontSettings() {
     localStorage.setItem('global-font-size', size.toString());
   };
 
+  const min = 12;
+  const max = 20;
+  const progress = ((fontSize - min) / (max - min)) * 100;
+
   return (
     <SettingCard
       title={translate({
@@ -213,7 +225,7 @@ function FontSettings() {
       })}
       description={translate({
         id: 'pages.settings.item.font.description',
-        message: 'Adjust the interface font to get the best reading experience',
+        message: 'Adjust interface text size',
       })}
       icon="lucide:type"
     >
@@ -229,12 +241,13 @@ function FontSettings() {
         </span>
         <input
           type="range"
-          min={12}
-          max={20}
+          min={min}
+          max={max}
           step={1}
           value={fontSize}
           onChange={(e) => handleSizeChange(parseInt(e.target.value, 10))}
           className={styles.slider}
+          style={{ '--slider-progress': `${progress}%` } as React.CSSProperties}
         />
         <div className={styles.sliderTicks}>
           <span>12px</span>
@@ -254,6 +267,7 @@ function ExperimentalFeatures() {
         id: 'pages.settings.item.experimental.option.originalLayout',
         message: 'Original Layout',
       }),
+      icon: 'lucide:layout-dashboard',
     },
     {
       key: 'debugMode' as const,
@@ -261,6 +275,15 @@ function ExperimentalFeatures() {
         id: 'pages.settings.item.experimental.option.debugMode',
         message: 'Debug Mode',
       }),
+      icon: 'lucide:terminal',
+    },
+    {
+      key: 'grayMode' as const,
+      label: translate({
+        id: 'pages.settings.item.experimental.option.grayMode',
+        message: 'Gray Mode',
+      }),
+      icon: 'lucide:contrast',
     },
   ];
   const [toggles, setToggles] = usePersistentState<
@@ -288,25 +311,28 @@ function ExperimentalFeatures() {
     <SettingCard
       title={translate({
         id: 'pages.settings.item.experimental.title',
-        message: 'Experimental Content',
+        message: 'Experimental Features',
       })}
       description={translate({
         id: 'pages.settings.item.experimental.description',
-        message: 'Try new features that are still under development',
+        message: 'Try features still in development',
       })}
       icon="lucide:flask-conical"
     >
-      <div className={styles.buttonGroup}>
+      <ul className={styles.toggleList}>
         {buttonOptions.map((option) => (
-          <div key={option.key} className={styles.toggleItem}>
-            <span>{option.label}</span>
+          <li key={option.key} className={styles.toggleItem}>
+            <span className={styles.toggleItemLabel}>
+              <Icon icon={option.icon} className={styles.toggleItemIcon} />
+              <span>{option.label}</span>
+            </span>
             <Switch
               checked={toggles[option.key]}
               onChange={(checked) => handleToggle(option.key, checked)}
             />
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
     </SettingCard>
   );
 }
@@ -368,23 +394,24 @@ function QuickActions() {
       })}
       description={translate({
         id: 'pages.settings.item.quickactions.description',
-        message: 'Quickly manage your personalized configuration',
+        message: 'Run common actions instantly',
       })}
       icon="lucide:zap"
     >
-      <div className={styles.buttonGroup}>
+      <ul className={styles.actionList}>
         {quickActionOptions.map((option) => (
-          <button
-            key={option.key}
-            className={styles.button}
-            onClick={option.onClick}
-          >
-            <IconText icon={option.icon} colorMode="monochrome">
-              {option.label}
-            </IconText>
-          </button>
+          <li key={option.key}>
+            <button
+              type="button"
+              className={styles.actionItem}
+              onClick={option.onClick}
+            >
+              <Icon icon={option.icon} className={styles.actionItemIcon} />
+              <span>{option.label}</span>
+            </button>
+          </li>
         ))}
-      </div>
+      </ul>
     </SettingCard>
   );
 }
@@ -409,8 +436,8 @@ function SettingsContainer() {
   return (
     <div className={styles.container}>
       <ThemeSettings />
-      <ColorGenerator />
-      <FontSettings />
+      <AccentColor />
+      <FontSize />
       <ExperimentalFeatures />
       <QuickActions />
     </div>

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -65,115 +65,172 @@
 }
 
 /* ==========================================================================
-   3. Interactive Elements
+   2. Card Header (icon kept from refined design)
    ========================================================================== */
 
-/* 按钮组 */
-.buttonGroup {
+.settingCard {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
 }
 
-.button {
+.cardHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cardIconWrapper {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
   border-radius: 12px;
-  border: 2px solid var(--ifm-color-emphasis-300);
-  background-color: var(--ifm-background-color);
-  color: var(--ifm-font-color-base);
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  white-space: nowrap;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ifm-color-primary-rgb), 0.16),
+    rgba(var(--ifm-color-primary-rgb), 0.08)
+  );
+  color: var(--ifm-color-primary);
+  border: 1px solid rgba(var(--ifm-color-primary-rgb), 0.18);
 }
 
-.button:hover {
-  border-color: var(--ifm-color-primary);
-  transform: translateY(-1px);
+html[data-theme='dark'] .cardIconWrapper {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--ifm-color-primary-rgb), 0.22),
+    rgba(var(--ifm-color-primary-rgb), 0.1)
+  );
+  color: var(--ifm-color-primary-light);
+  border-color: rgba(var(--ifm-color-primary-rgb), 0.28);
 }
 
-.buttonActive {
-  background: var(--ifm-color-primary);
-  border-color: var(--ifm-color-primary);
-  color: white;
-  box-shadow: 0 4px 12px rgba(var(--ifm-color-primary-rgb), 0.3);
+.cardIcon {
+  font-size: 1.4rem;
+  line-height: 1;
 }
 
-.buttonActive:hover {
-  background: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: white;
-}
-
-/* 滑块控件 */
-.sliderContainer {
+.cardTitleGroup {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.1rem;
+  flex: 1;
+  min-width: 0;
 }
 
-.sliderLabel {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-700);
+.cardTitle {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1.3;
+  color: var(--ifm-font-color-base);
 }
 
-.slider {
-  width: 100%;
-  height: 6px;
-  border-radius: 3px;
-  background: var(--ifm-color-emphasis-300);
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-.slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--ifm-color-primary);
-  cursor: pointer;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  transition: all 0.2s ease;
-  transform: scale(0.8);
-}
-
-.slider::-webkit-slider-thumb:hover {
-  transform: scale(1);
-}
-
-.slider::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background: var(--ifm-color-primary);
-  cursor: pointer;
-  border: none;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.sliderTicks {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.8rem;
+.cardDescription {
+  font-size: 0.875rem;
   color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+  line-height: 1.2;
+  margin: 0;
 }
 
-/* 切换列表 */
-.toggleItem {
+.cardBody {
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+/* ==========================================================================
+   3. Theme · Segmented Control (kept from refined design)
+   ========================================================================== */
+
+.segmented {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.3rem;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+}
+
+html[data-theme='dark'] .segmented {
+  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--ifm-color-emphasis-200);
+}
+
+.segmentItem {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 0;
+  gap: 0.65rem;
+  padding: 0.6rem 0.85rem;
+  border: none;
+  background: transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  color: var(--ifm-color-emphasis-700);
+  font-weight: 600;
+  font-size: 0.92rem;
+  text-align: left;
+  outline: none;
+  transition:
+    color 0.2s ease,
+    background 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s ease;
 }
+
+.segmentItem:hover {
+  color: var(--ifm-color-emphasis-900);
+  background: rgba(0, 0, 0, 0.03);
+}
+
+html[data-theme='dark'] .segmentItem:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.segmentItem:focus-visible {
+  box-shadow: 0 0 0 2px rgba(var(--ifm-color-primary-rgb), 0.4);
+}
+
+.segmentItemActive,
+.segmentItemActive:hover {
+  background: var(--ifm-card-background-color);
+  color: var(--ifm-color-primary);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 12px rgba(0, 0, 0, 0.06);
+}
+
+html[data-theme='dark'] .segmentItemActive,
+html[data-theme='dark'] .segmentItemActive:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-primary-light);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.segmentIcon {
+  font-size: 1.15rem;
+  flex-shrink: 0;
+}
+
+.segmentLabel {
+  flex: 1;
+  font-size: 0.92rem;
+  letter-spacing: 0.005em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ==========================================================================
+   4. Color Generator (original)
+   ========================================================================== */
 
 .colorGeneratorContainer {
   display: flex;
@@ -255,65 +312,206 @@
 
 .resetButton {
   flex-shrink: 0;
-  padding: 0.5rem 1rem;
-  background: var(--ifm-color-emphasis-200);
-  border: 1px solid var(--ifm-color-emphasis-300);
+  height: 30px;
+  padding: 0 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 2px solid var(--ifm-color-emphasis-300);
   border-radius: 8px;
   color: var(--ifm-color-emphasis-700);
   cursor: pointer;
-  font-size: 0.875rem;
-  transition: all 0.2s ease;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .resetButton:hover {
-  background: var(--ifm-color-emphasis-300);
-  border-color: var(--ifm-color-emphasis-400);
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
 }
 
 /* ==========================================================================
-   4. Additional Responsive Design
+   5. Font Size · Slider (kept from refined design)
    ========================================================================== */
 
-.cardHeader {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 2rem;
-}
-
-.cardIcon {
-  font-size: 1.75rem;
-  color: var(--ifm-color-primary);
-  flex-shrink: 0;
-  line-height: 1;
-}
-
-.cardTitleGroup {
+.sliderContainer {
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
-  flex: 1;
-  min-width: 0;
+  gap: 1rem;
 }
 
-.cardTitle {
-  font-size: 1.25rem;
-  font-weight: 700;
+.sliderLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.slider {
+  --slider-progress: 50%;
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary) var(--slider-progress),
+    var(--ifm-color-emphasis-200) var(--slider-progress),
+    var(--ifm-color-emphasis-200) 100%
+  );
+  -webkit-appearance: none;
+  appearance: none;
+  outline: none;
+  cursor: pointer;
+}
+
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  border: 3px solid var(--ifm-color-primary);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.slider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+}
+
+.slider::-moz-range-thumb {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  border: 3px solid var(--ifm-color-primary);
+  cursor: pointer;
+}
+
+.sliderTicks {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+  font-feature-settings: 'tnum';
+}
+
+/* ==========================================================================
+   6. Experimental · Toggle List (kept from refined design)
+   ========================================================================== */
+
+.toggleList {
+  list-style: none;
   margin: 0;
-  line-height: 1.3;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+}
+
+.toggleItem {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toggleItem + .toggleItem::before {
+  content: '';
+  position: absolute;
+  top: -0.7rem;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--ifm-color-emphasis-200);
+}
+
+.toggleItemLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  font-weight: 600;
   color: var(--ifm-font-color-base);
 }
 
-.cardDescription {
-  font-size: 0.875rem;
+.toggleItemIcon {
+  font-size: 1.1rem;
   color: var(--ifm-color-emphasis-600);
-  font-weight: 500;
-  line-height: 1.2;
-  margin: 0;
 }
 
-.cardBody {
-  flex-grow: 1;
+/* ==========================================================================
+   7. Quick Actions · Inverted Neutral Buttons
+   静态时为柔灰填充按钮，hover 时底色反白、主色仅作描边与文本/图标点缀
+   ========================================================================== */
+
+.actionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
+  gap: 1rem;
+}
+
+.actionItem {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.75rem 0.95rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: transparent;
+  border-radius: 10px;
+  cursor: pointer;
+  color: var(--ifm-font-color-base);
+  font-weight: 600;
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+  text-align: left;
+  outline: none;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.actionItem:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+html[data-theme='dark'] .actionItem:hover {
+  color: var(--ifm-color-primary-light);
+  border-color: var(--ifm-color-primary-light);
+}
+
+.actionItem:focus-visible {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.2);
+}
+
+.actionItemIcon {
+  flex-shrink: 0;
+  font-size: 1.05rem;
+  color: var(--ifm-color-emphasis-700);
+  transition: color 0.2s ease;
+}
+
+.actionItem:hover .actionItemIcon {
+  color: var(--ifm-color-primary);
+}
+
+html[data-theme='dark'] .actionItem:hover .actionItemIcon {
+  color: var(--ifm-color-primary-light);
 }

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -14,10 +14,12 @@ import LayoutProvider from '@theme/Layout/Provider';
 import ErrorPageContent from '@theme/ErrorPageContent';
 import type { Props } from '@theme/Layout';
 import { useDebugMode } from '@site/src/hooks/useDebugMode';
+import { useGrayMode } from '@site/src/hooks/useGrayMode';
 import styles from './styles.module.css';
 
 export default function Layout(props: Props): ReactNode {
   const debugMode = useDebugMode();
+  const grayMode = useGrayMode();
   const {
     children,
     noFooter,
@@ -28,7 +30,12 @@ export default function Layout(props: Props): ReactNode {
   } = props;
 
   return (
-    <div className={clsx(debugMode && styles.debugMode)}>
+    <div
+      className={clsx(
+        debugMode && styles.debugMode,
+        grayMode && styles.grayMode
+      )}
+    >
       <LayoutProvider>
         <PageMetadata title={title} description={description} />
 

--- a/src/theme/Layout/styles.module.css
+++ b/src/theme/Layout/styles.module.css
@@ -6,9 +6,9 @@
   outline: 1px solid orange;
 }
 
-/* .grayMode {
+.grayMode {
   filter: grayscale(100%);
-} */
+}
 
 html,
 body {

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -98,7 +98,7 @@ export function getAdjustedColors(
   return Object.keys(shades).map((shade) => ({
     ...shades[shade]!,
     variableName: shade,
-    hex: Color(baseColor).darken(shades[shade]!.adjustment).hex(),
+    hex: Color(baseColor).darken(shades[shade]!.adjustment).hex().toLowerCase(),
   }));
 }
 
@@ -131,12 +131,16 @@ export function updateDOMColors(
       ? `\n  --ifm-background-color: ${background};`
       : '';
 
+  // 同步更新 --ifm-color-primary-rgb，让依赖该变量的 rgba 颜色跟随主题色
+  const rgb = Color(baseColor).rgb().array();
+  const rgbRule = `\n  --ifm-color-primary-rgb: ${Math.round(rgb[0]!)}, ${Math.round(rgb[1]!)}, ${Math.round(rgb[2]!)};`;
+
   const overrideStyle = `${
     isDarkTheme ? '[data-theme="dark"]' : '[data-theme="light"]'
   } {
   ${getAdjustedColors(shades, baseColor)
     .map((value) => `  ${value.variableName}: ${value.hex};`)
-    .join('\n')}${backgroundRule}
+    .join('\n')}${rgbRule}${backgroundRule}
 }`;
   styleSheet.insertRule(overrideStyle, styleSheet.cssRules.length - 1);
 }


### PR DESCRIPTION
- Refine settings cards: section icons, segmented theme picker, font size slider, toggle list, quick action buttons
- Add gray mode (mourning mode) toggle and useGrayMode hook
- Define --ifm-color-primary-rgb and sync it with color generator
- Lowercase hex output and fix invalid color crash in updateColor