### PR TITLE
Add cookie consent banner

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -928,5 +928,20 @@
   },
   "data.changelog.type.security": {
     "message": "【安全】"
+  },
+  "cookieConsent.title": {
+    "message": "Cookie 设置"
+  },
+  "cookieConsent.description": {
+    "message": "本站使用 Cookie 记录你的偏好，以改善浏览体验。{learnMore}。"
+  },
+  "cookieConsent.learnMore": {
+    "message": "了解更多"
+  },
+  "cookieConsent.accept": {
+    "message": "接受"
+  },
+  "cookieConsent.reject": {
+    "message": "拒绝"
   }
 }

--- a/src/components/laikit/CookieConsent/index.tsx
+++ b/src/components/laikit/CookieConsent/index.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from 'react';
+import Link from '@docusaurus/Link';
+import Translate from '@docusaurus/Translate';
+import styles from './styles.module.css';
+
+const STORAGE_KEY = 'cookie-consent';
+
+type ConsentValue = 'accepted' | 'rejected';
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored !== 'accepted' && stored !== 'rejected') {
+        setVisible(true);
+      }
+    } catch {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleChoice = (value: ConsentValue) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, value);
+    } catch {
+      // ignore storage errors (private mode, etc.)
+    }
+    setVisible(false);
+  };
+
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={styles.banner}
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie consent"
+    >
+      <div className={styles.content}>
+        <div className={styles.title}>
+          <Translate id="cookieConsent.title">Cookie Settings</Translate>
+        </div>
+        <p className={styles.description}>
+          <Translate
+            id="cookieConsent.description"
+            values={{
+              learnMore: (
+                <Link to="/privacy" className={styles.link}>
+                  <Translate id="cookieConsent.learnMore">Learn more</Translate>
+                </Link>
+              ),
+            }}
+          >
+            {
+              'This site uses cookies to remember your preferences and improve your browsing experience. {learnMore}.'
+            }
+          </Translate>
+        </p>
+        <div className={styles.actions}>
+          <button
+            type="button"
+            className={`${styles.button} ${styles.reject}`}
+            onClick={() => handleChoice('rejected')}
+          >
+            <Translate id="cookieConsent.reject">Reject</Translate>
+          </button>
+          <button
+            type="button"
+            className={`${styles.button} ${styles.accept}`}
+            onClick={() => handleChoice('accepted')}
+          >
+            <Translate id="cookieConsent.accept">Accept</Translate>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/laikit/CookieConsent/styles.module.css
+++ b/src/components/laikit/CookieConsent/styles.module.css
@@ -1,0 +1,109 @@
+.banner {
+  position: fixed;
+  z-index: 200;
+  left: 1rem;
+  bottom: 1rem;
+  right: auto;
+  max-width: 380px;
+  width: calc(100% - 2rem);
+  background: var(--ifm-card-background-color, var(--ifm-background-color));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  padding: 1rem 1.125rem;
+  animation: cookieConsentIn 200ms ease-out;
+}
+
+html[data-theme='dark'] .banner {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ifm-heading-color);
+}
+
+.description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.link {
+  color: var(--ifm-color-primary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+}
+
+.button {
+  appearance: none;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.reject {
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
+}
+
+.reject:hover {
+  border-color: var(--ifm-color-emphasis-500);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.accept {
+  background: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  color: var(--ifm-button-color, #fff);
+}
+
+.accept:hover {
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+}
+
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.24);
+}
+
+@media (max-width: 480px) {
+  .banner {
+    left: 0.75rem;
+    bottom: 0.75rem;
+    width: calc(100% - 1.5rem);
+  }
+}
+
+@keyframes cookieConsentIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/data/changelog.tsx
+++ b/src/data/changelog.tsx
@@ -8,9 +8,19 @@ interface ChangelogItem {
 
 export const CHANGELOG_LIST: ChangelogItem[] = [
   {
+    date: '2026-04-26',
+    type: 'added',
+    content: 'Cookie 授权弹窗',
+  },
+  {
     date: '2026-04-25',
     type: 'added',
     content: '网站灰色模式',
+  },
+  {
+    date: '2026-04-25',
+    type: 'added',
+    content: '备用网站 <code>lailai0916.com</code>',
   },
   {
     date: '2026-04-19',

--- a/src/theme/Root/index.tsx
+++ b/src/theme/Root/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, type ReactNode } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
 import { ThemeContext } from '@site/src/hooks/useTheme';
+import CookieConsent from '@site/src/components/laikit/CookieConsent';
 
 interface RootProps {
   children: ReactNode;
@@ -49,6 +51,7 @@ export default function Root({ children }: RootProps) {
   return (
     <ThemeContext.Provider value={{ isOriginalLayout, setIsOriginalLayout }}>
       {children}
+      <BrowserOnly>{() => <CookieConsent />}</BrowserOnly>
     </ThemeContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- Add a first-visit cookie consent banner anchored to the bottom-left corner, styled with the site's existing card tokens (light/dark aware).
- Persist the user's choice (`accepted` / `rejected`) under `localStorage['cookie-consent']` so the banner stays dismissed.
- Wire it into `src/theme/Root/index.tsx` via `<BrowserOnly>` so SSR is unaffected.
- Add zh-Hans translations for the 5 banner strings.
- Changelog: new entry for the consent banner; back-fill 4/25 entry for the `lailai0916.com` backup site.

## Test plan
- [x] Banner appears on first visit, link to `/privacy` works
- [x] Accept / Reject both persist and dismiss; reload does not re-show
- [x] Renders correctly in light and dark themes
- [x] zh-Hans locale shows translated copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)