### PR TITLE
Use IconBlock for Resources and Friends card icons

### DIFF
--- a/src/components/laikit/IconBlock/index.tsx
+++ b/src/components/laikit/IconBlock/index.tsx
@@ -4,11 +4,12 @@ import { Icon } from '@iconify/react';
 import styles from './styles.module.css';
 
 interface IconBlockProps {
-  icon: string;
+  icon?: string;
   variant?: 'accent' | 'muted';
   size?: number;
   iconSize?: number;
   className?: string;
+  children?: React.ReactNode;
 }
 
 export default function IconBlock({
@@ -17,6 +18,7 @@ export default function IconBlock({
   size = 40,
   iconSize,
   className,
+  children,
 }: IconBlockProps) {
   const resolvedIconSize = iconSize ?? Math.round(size * 0.5);
   return (
@@ -24,7 +26,11 @@ export default function IconBlock({
       className={clsx(styles.iconBlock, styles[variant], className)}
       style={{ '--icon-block-size': `${size}px` } as React.CSSProperties}
     >
-      <Icon icon={icon} width={resolvedIconSize} height={resolvedIconSize} />
+      {icon ? (
+        <Icon icon={icon} width={resolvedIconSize} height={resolvedIconSize} />
+      ) : (
+        children
+      )}
     </div>
   );
 }

--- a/src/components/laikit/IconBlock/styles.module.css
+++ b/src/components/laikit/IconBlock/styles.module.css
@@ -7,6 +7,7 @@
   justify-content: center;
   border-radius: 12px;
   line-height: 1;
+  overflow: hidden;
 }
 
 /* Primary tinted variant - for highlighted/feature icons */

--- a/src/pages/friends/index.tsx
+++ b/src/pages/friends/index.tsx
@@ -3,7 +3,7 @@ import Layout from '@theme/Layout';
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import Card from '@site/src/components/laikit/Card';
-import { Icon } from '@iconify/react';
+import IconBlock from '@site/src/components/laikit/IconBlock';
 import { FriendItem, FRIEND_LIST } from '@site/src/data/friends';
 import { translate } from '@docusaurus/Translate';
 import styles from './styles.module.css';
@@ -33,20 +33,23 @@ function FriendCard({ friend }: { friend: FriendItem }) {
       padding="1.5rem"
     >
       <div className={styles.friendCardHeader}>
-        <div className={styles.friendCardAvatar}>
-          {!imageError && friend.avatar ? (
+        {!imageError && friend.avatar ? (
+          <IconBlock variant="muted" size={60}>
             <img
               src={friend.avatar}
               alt={friend.title}
               className={styles.friendCardImage}
               onError={() => setImageError(true)}
             />
-          ) : (
-            <div className={styles.friendCardFallback}>
-              <Icon icon="lucide:user" width={24} height={24} />
-            </div>
-          )}
-        </div>
+          </IconBlock>
+        ) : (
+          <IconBlock
+            icon="lucide:user"
+            variant="muted"
+            size={60}
+            iconSize={24}
+          />
+        )}
         <div className={styles.friendCardInfo}>
           <h3 className={styles.friendCardTitle}>{friend.title}</h3>
           <p className={styles.friendCardDescription}>

--- a/src/pages/friends/styles.module.css
+++ b/src/pages/friends/styles.module.css
@@ -34,34 +34,10 @@
   gap: 1rem;
 }
 
-.friendCardAvatar {
-  flex-shrink: 0;
-  width: 60px;
-  height: 60px;
-  border-radius: 12px;
-  overflow: hidden;
-  background: var(--ifm-color-emphasis-100);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .friendCardImage {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 12px;
-}
-
-.friendCardFallback {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-500);
-  border-radius: 12px;
 }
 
 .friendCardInfo {
@@ -111,22 +87,9 @@
     align-items: center;
   }
 
-  .friendCardAvatar {
-    align-self: center;
-  }
-
   .friendCardInfo {
     width: 100%;
   }
-}
-
-/* ==========================================================================
-   7. Dark Mode
-   ========================================================================== */
-
-html[data-theme='dark'] .friendCardFallback {
-  background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-emphasis-600);
 }
 
 /* ==========================================================================

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -6,6 +6,7 @@ import Layout from '@theme/Layout';
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import Card from '@site/src/components/laikit/Card';
+import IconBlock from '@site/src/components/laikit/IconBlock';
 import IconText from '@site/src/components/laikit/IconText';
 
 import { usePluralForm } from '@docusaurus/theme-common';
@@ -130,6 +131,7 @@ function ResourceCard({
   resource: { title: string; description: string; href: string };
 }) {
   const iconUrl = `https://www.google.com/s2/favicons?sz=64&domain=${new URL(resource.href).hostname}`;
+  const [imageError, setImageError] = useState(false);
 
   return (
     <Card
@@ -138,29 +140,23 @@ function ResourceCard({
       wrapperClassName={styles.resourceCardLink}
       title={resource.title}
     >
-      <div className={styles.resourceCardIcon}>
-        {iconUrl && (
+      {imageError ? (
+        <IconBlock
+          icon="lucide:globe"
+          variant="muted"
+          size={48}
+          iconSize={24}
+        />
+      ) : (
+        <IconBlock variant="muted" size={48}>
           <img
             src={iconUrl}
             alt={resource.title}
             className={styles.resourceCardImage}
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-              const fallback = e.currentTarget
-                .nextElementSibling as HTMLElement | null;
-              if (fallback) fallback.style.display = 'flex';
-            }}
+            onError={() => setImageError(true)}
           />
-        )}
-        <div
-          className={clsx(
-            styles.resourceCardFallback,
-            !iconUrl && styles.resourceCardFallbackVisible
-          )}
-        >
-          <Icon icon="lucide:globe" width={24} height={24} />
-        </div>
-      </div>
+        </IconBlock>
+      )}
       <div className={styles.resourceCardBody}>
         <h3 className={styles.resourceCardTitle}>{resource.title}</h3>
         <p className={styles.resourceCardDescription}>{resource.description}</p>

--- a/src/pages/resources/styles.module.css
+++ b/src/pages/resources/styles.module.css
@@ -154,36 +154,10 @@
   height: 100%;
 }
 
-.resourceCardIcon {
-  flex-shrink: 0;
-  position: relative;
-  width: 48px;
-  height: 48px;
-  background: var(--ifm-color-emphasis-100);
-  border-radius: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
 .resourceCardImage {
   width: 24px;
   height: 24px;
   object-fit: contain;
-}
-
-.resourceCardFallback {
-  display: none;
-  color: var(--ifm-color-emphasis-600);
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-}
-
-.resourceCardFallbackVisible {
-  display: flex;
 }
 
 .resourceCardBody {


### PR DESCRIPTION
## Summary
- Extend `IconBlock` to accept `children` (image or arbitrary node) as an alternative to the Iconify `icon` string, and add `overflow: hidden` so children are clipped to the rounded box.
- Route Resources favicon image and Friends avatar through `IconBlock` (`variant="muted"`, `size={48}` and `size={60}` respectively); fallback states use `IconBlock` with a Lucide icon.
- Drop the now-duplicated `.resourceCardIcon` / `.resourceCardFallback*` and `.friendCardAvatar` / `.friendCardFallback` styles.

## Test plan
- [x] Resources cards: 48×48 muted block with 24×24 favicon; globe fallback when image errors
- [x] Friends cards: 60×60 muted block; avatar fills the rounded box; user fallback when avatar missing/errored
- [x] Light and dark themes look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)