### PR TITLE
Build CookieConsent on top of Card

### DIFF
--- a/src/components/CookieConsent/index.tsx
+++ b/src/components/CookieConsent/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
+import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
 const STORAGE_KEY = 'cookie-consent';
@@ -41,43 +42,47 @@ export default function CookieConsent() {
       aria-live="polite"
       aria-label="Cookie consent"
     >
-      <div className={styles.content}>
-        <div className={styles.title}>
-          <Translate id="cookieConsent.title">Cookie Settings</Translate>
+      <Card padding="1rem 1.125rem" className={styles.card}>
+        <div className={styles.content}>
+          <div className={styles.title}>
+            <Translate id="cookieConsent.title">Cookie Settings</Translate>
+          </div>
+          <p className={styles.description}>
+            <Translate
+              id="cookieConsent.description"
+              values={{
+                learnMore: (
+                  <Link to="/privacy" className={styles.link}>
+                    <Translate id="cookieConsent.learnMore">
+                      Learn more
+                    </Translate>
+                  </Link>
+                ),
+              }}
+            >
+              {
+                'This site uses cookies to remember your preferences and improve your browsing experience. {learnMore}.'
+              }
+            </Translate>
+          </p>
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.reject}`}
+              onClick={() => handleChoice('rejected')}
+            >
+              <Translate id="cookieConsent.reject">Reject</Translate>
+            </button>
+            <button
+              type="button"
+              className={`${styles.button} ${styles.accept}`}
+              onClick={() => handleChoice('accepted')}
+            >
+              <Translate id="cookieConsent.accept">Accept</Translate>
+            </button>
+          </div>
         </div>
-        <p className={styles.description}>
-          <Translate
-            id="cookieConsent.description"
-            values={{
-              learnMore: (
-                <Link to="/privacy" className={styles.link}>
-                  <Translate id="cookieConsent.learnMore">Learn more</Translate>
-                </Link>
-              ),
-            }}
-          >
-            {
-              'This site uses cookies to remember your preferences and improve your browsing experience. {learnMore}.'
-            }
-          </Translate>
-        </p>
-        <div className={styles.actions}>
-          <button
-            type="button"
-            className={`${styles.button} ${styles.reject}`}
-            onClick={() => handleChoice('rejected')}
-          >
-            <Translate id="cookieConsent.reject">Reject</Translate>
-          </button>
-          <button
-            type="button"
-            className={`${styles.button} ${styles.accept}`}
-            onClick={() => handleChoice('accepted')}
-          >
-            <Translate id="cookieConsent.accept">Accept</Translate>
-          </button>
-        </div>
-      </div>
+      </Card>
     </div>
   );
 }

--- a/src/components/CookieConsent/styles.module.css
+++ b/src/components/CookieConsent/styles.module.css
@@ -3,18 +3,16 @@
   z-index: 200;
   left: 1rem;
   bottom: 1rem;
-  right: auto;
   max-width: 380px;
   width: calc(100% - 2rem);
-  background: var(--ifm-card-background-color, var(--ifm-background-color));
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 16px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
-  padding: 1rem 1.125rem;
   animation: cookieConsentIn 200ms ease-out;
 }
 
-html[data-theme='dark'] .banner {
+.card {
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+html[data-theme='dark'] .card {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
 }
 


### PR DESCRIPTION
## Summary
- Wrap the cookie consent banner in the laikit `<Card>` primitive instead of duplicating its background / border / radius / padding rules.
- `.banner` now only owns position + z-index + sizing + entry animation.
- `.card` only overrides Card's default shadow with a heavier floating shadow (and dark-mode variant), since this surface floats above the page.

## Why
Keeps the banner visually consistent with other Card surfaces on the site and avoids drift when Card's tokens change.

## Test plan
- [x] First-visit banner still renders bottom-left, with the expected card surface
- [x] Computed styles match: bg `--ifm-card-background-color`, 1px emphasis-200 border, 16px radius, padding 16×18, heavier 12/32 shadow
- [x] Accept / Reject persist and dismiss; reload does not re-show
- [x] Light + dark themes look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)