### PR TITLE
Fix Devices image AR bug, redesign Community as compact cards

### DIFF
--- a/src/pages/about/_components.tsx
+++ b/src/pages/about/_components.tsx
@@ -1,10 +1,9 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import BrowserOnly from '@docusaurus/BrowserOnly';
-import Link from '@docusaurus/Link';
 import Giscus from '@giscus/react';
+import { Icon } from '@iconify/react';
 import Card from '@site/src/components/laikit/Card';
-import IconText from '@site/src/components/laikit/IconText';
 import { useColorMode } from '@docusaurus/theme-common';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 
@@ -54,6 +53,39 @@ export function Skills() {
   );
 }
 
+function DeviceImage({ src, alt }: { src: string; alt: string }) {
+  const ref = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    const img = ref.current;
+    if (!img) return;
+    const setAr = () => {
+      if (img.naturalWidth) {
+        img.style.setProperty(
+          '--ar',
+          String(img.naturalWidth / img.naturalHeight)
+        );
+      }
+    };
+    if (img.complete) {
+      setAr();
+      return;
+    }
+    img.addEventListener('load', setAr);
+    return () => img.removeEventListener('load', setAr);
+  }, []);
+
+  return (
+    <img
+      ref={ref}
+      src={src}
+      alt={alt}
+      className={styles.deviceImage}
+      loading="lazy"
+    />
+  );
+}
+
 export function Devices() {
   return (
     <div className={styles.deviceGrid}>
@@ -63,19 +95,7 @@ export function Devices() {
             <div className={styles.deviceName}>{item.title}</div>
             <div className={styles.deviceSpec}>{item.spec}</div>
           </div>
-          <img
-            src={item.image}
-            alt={item.title}
-            className={styles.deviceImage}
-            loading="lazy"
-            onLoad={(e) => {
-              const img = e.currentTarget;
-              img.style.setProperty(
-                '--ar',
-                String(img.naturalWidth / img.naturalHeight)
-              );
-            }}
-          />
+          <DeviceImage src={item.image} alt={item.title} />
         </Card>
       ))}
     </div>
@@ -83,27 +103,22 @@ export function Devices() {
 }
 
 export function Community() {
-  const columns = useMemo(() => {
-    return [
-      COMMUNITY_LIST.filter((_, i) => i % 2 === 0),
-      COMMUNITY_LIST.filter((_, i) => i % 2 === 1),
-    ];
-  }, []);
-
   return (
-    <div className={styles.twoColumnContainer}>
-      {columns.map((columnItems, index) => (
-        <div key={index} className={styles.column}>
-          {columnItems.map((item) => (
-            <div key={item.title} className={styles.listItem}>
-              <IconText icon={item.icon} colorMode="monochrome">
-                <Link to={item.href} style={{ color: 'inherit' }}>
-                  {item.text}
-                </Link>
-              </IconText>
-            </div>
-          ))}
-        </div>
+    <div className={styles.communityGrid}>
+      {COMMUNITY_LIST.map((item) => (
+        <Card
+          key={item.title}
+          href={item.href}
+          padding="0.75rem"
+          className={styles.communityCard}
+          wrapperClassName={styles.communityCardWrapper}
+        >
+          <div className={styles.communityCardBody}>
+            <div className={styles.communityName}>{item.title}</div>
+            <div className={styles.communitySpec}>{item.text}</div>
+          </div>
+          <Icon icon={item.icon} className={styles.communityIcon} />
+        </Card>
       ))}
     </div>
   );

--- a/src/pages/about/styles.module.css
+++ b/src/pages/about/styles.module.css
@@ -1,38 +1,5 @@
-.twoColumnContainer {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-}
-
-@media (max-width: 576px) {
-  .twoColumnContainer {
-    grid-template-columns: 1fr;
-  }
-}
-
-.column {
-  display: flex;
-  flex-direction: column;
-}
-
-.listItem {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-bottom: 1rem;
-}
-
-.deviceIcon {
-  width: 1.25rem;
-  height: 1.25rem;
-  user-select: none;
-  pointer-events: none;
-}
-
-html[data-theme='dark'] .deviceIcon {
-  filter: invert(1);
-}
-
-.deviceGrid {
+.deviceGrid,
+.communityGrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1rem;
@@ -40,7 +7,8 @@ html[data-theme='dark'] .deviceIcon {
 }
 
 @media (max-width: 576px) {
-  .deviceGrid {
+  .deviceGrid,
+  .communityGrid {
     grid-template-columns: 1fr;
   }
 }
@@ -91,15 +59,60 @@ html[data-theme='dark'] .deviceIcon {
   object-position: left center;
   pointer-events: none;
   user-select: none;
-  opacity: 0.55;
+  opacity: 0.5;
   transition: opacity 200ms ease;
   z-index: 0;
 }
 
-html[data-theme='dark'] .deviceImage {
-  opacity: 0.45;
-}
-
 .deviceCard:hover .deviceImage {
   opacity: 1;
+}
+
+.communityCardWrapper {
+  --link-card-accent: var(--ifm-color-emphasis-200);
+}
+
+.communityCard {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.communityIcon {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  color: var(--ifm-color-emphasis-700);
+  pointer-events: none;
+  opacity: 0.5;
+  transition: opacity 200ms ease;
+}
+
+.communityCardWrapper:hover .communityIcon,
+.communityCardWrapper:focus-visible .communityIcon {
+  opacity: 1;
+}
+
+.communityCardBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.communityName {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--ifm-heading-color);
+}
+
+.communitySpec {
+  font-size: 0.78rem;
+  line-height: 1.3;
+  color: var(--ifm-color-emphasis-700);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }


### PR DESCRIPTION
## Summary

### Devices: cached-image AR bug
The MacBook image was sometimes rendering as a small square on GitHub Pages (more often than not on repeat visits). Cause: `<img onLoad>` only fires after React hydration; if the PNG was already cached and loaded before hydration, the listener never received the event, so `--ar` stayed at the default `1` and CSS picked the square fallback. MacBook is the most affected because its aspect ratio (~1.64) is the furthest from 1, and `object-fit: contain` masks the same bug for the other (taller-than-wide) images.

Fix: extract the `<img>` into a `DeviceImage` subcomponent that runs `useEffect` on mount and uses `img.complete && img.naturalWidth` to set `--ar` immediately when the image is already loaded, falling back to a `load` listener otherwise. Standard React idiom for this class of bugs.

### Community: list → card grid
Rewrote the `IconText`-based list as a card grid that mirrors the Devices layout. Each card is now a clickable `Card` with a 28px icon on the left and title + handle on the right. Compact (about 62px tall) so eight cards still fit comfortably on the About page.

- Default state: icon faded to `opacity: 0.5`
- Hover/focus the card: icon transitions to full opacity over 200ms
- The `Card` hover border is suppressed (override `--link-card-accent`) so only the icon reacts

### Unified decorative opacity
Both Devices images and Community icons use `opacity: 0.5` in default state and `1` on hover, dropping the per-theme override.

## Test plan
- [ ] On About page, MacBook image renders at ~144x88 (correct AR), even after hard reload / cached navigation
- [ ] Community grid renders 2 columns on desktop, 1 column under 576px
- [ ] Clicking a Community card navigates to the correct URL (note: external links open in a new tab via Docusaurus Link defaults)
- [ ] Hover a Community card: icon fades to full opacity, border stays neutral
- [ ] Light + dark themes both show identical 0.5 default opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)