### PR TITLE
Tone down hover displacement effects

### DIFF
--- a/src/pages/resources/styles.module.css
+++ b/src/pages/resources/styles.module.css
@@ -78,7 +78,6 @@
 
 .categoryButton:hover {
   border-color: var(--ifm-color-primary);
-  transform: translateY(-1px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -224,7 +224,7 @@
 }
 
 .slider::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
+  transform: scale(1.1);
 }
 
 .slider::-moz-range-thumb {

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -144,7 +144,6 @@
 
 .infoItem:hover .infoItemArrow {
   color: var(--ifm-color-primary);
-  transform: translateX(1px);
 }
 
 .statsGrid {


### PR DESCRIPTION
## Summary
- Remove `transform: translateY(-1px)` from `.categoryButton:hover` on the Resources page
- Remove `transform: translateX(1px)` from `.infoItem:hover .infoItemArrow` in the blog shared theme
- Reduce `.slider::-webkit-slider-thumb:hover` scale from `1.15` to `1.1` on the Settings page

The slight shifts on hover were distracting. Border-color and box-shadow feedback is preserved on the category button; color change is preserved on the blog info item arrow.

## Test plan
- [x] Verified via local dev server that `.categoryButton` no longer translates on hover (computed `transform: none`)
- [x] Verified the `.infoItemArrow` hover rule no longer contains `transform`
- [x] Verified the slider thumb hover rule now reads `scale(1.1)`
- [ ] Spot-check Resources, Blog list, and Settings pages in light/dark mode after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)