### PR TITLE
Animate Fourier path with draw/erase cycle

### DIFF
--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -93,6 +93,8 @@ export default function FourierTransformCanvas() {
     fourierX: [] as FourierCoefficient[],
     path: [] as Point[],
     time: 0,
+    phase: 'draw' as 'draw' | 'erase',
+    eraseIndex: 0,
   });
 
   // Theme colors live in a ref so theme changes don't restart the animation effect.
@@ -138,6 +140,8 @@ export default function FourierTransformCanvas() {
     state.currentState = STATE.PLAYING;
     state.path = [];
     state.time = 0;
+    state.phase = 'draw';
+    state.eraseIndex = 0;
   };
 
   const captureDrawing = (drawn: Point[]) => {
@@ -291,14 +295,25 @@ export default function FourierTransformCanvas() {
         }
 
         const v = drawEpicycles();
-        state.path.push(v);
-        drawPath(state.path);
+        if (state.phase === 'draw') {
+          state.path.push(v);
+          drawPath(state.path);
+        } else {
+          state.eraseIndex++;
+          drawPath(state.path.slice(state.eraseIndex));
+        }
 
         const dt = TWO_PI / state.fourierX.length;
         state.time += dt;
         if (state.time > TWO_PI) {
           state.time = 0;
-          state.path = [];
+          if (state.phase === 'draw') {
+            state.phase = 'erase';
+            state.eraseIndex = 0;
+          } else {
+            state.phase = 'draw';
+            state.path = [];
+          }
         }
       }
 
@@ -333,6 +348,8 @@ export default function FourierTransformCanvas() {
     state.drawing = [point];
     state.path = [];
     state.time = 0;
+    state.phase = 'draw';
+    state.eraseIndex = 0;
   };
 
   const handleMove = (e: React.MouseEvent | React.TouchEvent) => {


### PR DESCRIPTION
## Summary

Previously the traced path on the Fourier Transform homepage component snapped back to empty at the end of each period, which felt abrupt. This change splits each period into two phases:

- **Draw phase**: cursor traces the trajectory and accumulates the path in primary color (existing behavior).
- **Erase phase**: cursor sweeps the same trajectory again and erases the path from the start, so the visual cursor "eats" its own trail as it goes.

The faint outline of the underlying drawing remains visible throughout.

## Implementation

In [FourierTransformCanvas.tsx](src/pages/_components/FourierTransform/FourierTransformCanvas.tsx), the animation state ref gains two fields:

- `phase: 'draw' | 'erase'`
- `eraseIndex: number` — number of leading points already erased

In the render loop, draw phase pushes points to `state.path` and renders all of it; erase phase increments `eraseIndex` and renders `state.path.slice(eraseIndex)`. Each time `state.time` wraps past `2π`, the phase toggles (and `path` is cleared at the end of erase).

`rebuildFromBase` and `handleStart` were updated to reset the new fields alongside the existing path/time reset.

## Test plan

- [ ] Open the homepage, scroll past the cover, and watch the default heart: it should fill in with primary color over one period, then be erased point-by-point along the same trajectory in the next period, looping smoothly.
- [ ] Draw a custom shape on the canvas and confirm the same draw → erase cycle applies to the user-drawn shape.
- [ ] Toggle dark/light theme during the animation and confirm both phases keep working.
- [ ] Resize the window and confirm the animation continues without artifacts.