### PR TITLE
Sample drawing input with coalesced pointer events

### DIFF
--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -326,22 +326,21 @@ export default function FourierTransformCanvas() {
     return () => cancelAnimationFrame(animationId);
   }, [canvasSize, dpr, isDark]);
 
-  const getCanvasCoords = (e: React.MouseEvent | React.Touch): Point | null => {
+  const getCanvasCoords = (clientX: number, clientY: number): Point | null => {
     const canvas = canvasRef.current;
     if (!canvas) return null;
     const rect = canvas.getBoundingClientRect();
     return {
-      x: e.clientX - rect.left - rect.width / 2,
-      y: e.clientY - rect.top - rect.height / 2,
+      x: clientX - rect.left - rect.width / 2,
+      y: clientY - rect.top - rect.height / 2,
     };
   };
 
-  const handleStart = (e: React.MouseEvent | React.TouchEvent) => {
-    const point =
-      'touches' in e
-        ? getCanvasCoords(e.touches[0])
-        : getCanvasCoords(e as React.MouseEvent);
+  const handleStart = (e: React.PointerEvent) => {
+    const point = getCanvasCoords(e.clientX, e.clientY);
     if (!point) return;
+
+    e.currentTarget.setPointerCapture(e.pointerId);
 
     const state = stateRef.current;
     state.currentState = STATE.DRAWING;
@@ -352,22 +351,31 @@ export default function FourierTransformCanvas() {
     state.eraseIndex = 0;
   };
 
-  const handleMove = (e: React.MouseEvent | React.TouchEvent) => {
+  const handleMove = (e: React.PointerEvent) => {
     const state = stateRef.current;
     if (state.currentState !== STATE.DRAWING) return;
 
-    const point =
-      'touches' in e
-        ? getCanvasCoords(e.touches[0])
-        : getCanvasCoords(e as React.MouseEvent);
-    if (!point) return;
+    // Use coalesced events for finer-grained samples on high-frequency input
+    // devices (Apple Pencil, drawing tablet). Falls back to the dispatched
+    // event itself when no extra samples are available.
+    const native = e.nativeEvent;
+    const coalesced =
+      typeof native.getCoalescedEvents === 'function'
+        ? native.getCoalescedEvents()
+        : [];
+    const samples: { clientX: number; clientY: number }[] =
+      coalesced.length > 0 ? coalesced : [native];
 
-    const lastPoint = state.drawing[state.drawing.length - 1];
-    if (
-      !lastPoint ||
-      Math.hypot(point.x - lastPoint.x, point.y - lastPoint.y) >= 1
-    ) {
-      state.drawing.push(point);
+    for (const sample of samples) {
+      const point = getCanvasCoords(sample.clientX, sample.clientY);
+      if (!point) continue;
+      const lastPoint = state.drawing[state.drawing.length - 1];
+      if (
+        !lastPoint ||
+        Math.hypot(point.x - lastPoint.x, point.y - lastPoint.y) >= 1
+      ) {
+        state.drawing.push(point);
+      }
     }
   };
 
@@ -389,13 +397,10 @@ export default function FourierTransformCanvas() {
         height={canvasSize * dpr}
         style={{ width: canvasSize, height: canvasSize }}
         className={styles.canvas}
-        onMouseDown={handleStart}
-        onMouseMove={handleMove}
-        onMouseUp={handleEnd}
-        onMouseLeave={handleEnd}
-        onTouchStart={handleStart}
-        onTouchMove={handleMove}
-        onTouchEnd={handleEnd}
+        onPointerDown={handleStart}
+        onPointerMove={handleMove}
+        onPointerUp={handleEnd}
+        onPointerCancel={handleEnd}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Switches the Fourier Transform canvas drawing input from separate mouse + touch event handlers to a unified pointer event API, and uses `PointerEvent.getCoalescedEvents()` to read the high-frequency intermediate samples that browsers normally merge into a single dispatched `pointermove`.

## Why

The previous handlers picked up exactly one position per dispatched event. On 240Hz pen / drawing-tablet input, browsers coalesce 4–8 raw samples into each dispatched event, so most of the precision was being thrown away. The drawn shape lost subtle curvature at any meaningful stroke speed.

For ordinary mice (where coalescing rarely produces extra samples) the behavior is identical to before: the `≥1px` distance filter still applies, point counts and DFT cost are unchanged.

## Implementation

- `getCanvasCoords` now takes `clientX, clientY` directly instead of an event-shaped object — same call site at all three usages.
- `handleStart` / `handleMove` / `handleEnd` are now `React.PointerEvent` handlers.
- `handleMove` reads `e.nativeEvent.getCoalescedEvents()` and iterates each sample through the same `≥1px` filter; falls back to the dispatched event when the list is empty (no coalescing or older browsers).
- `setPointerCapture` is called on `pointerdown` so a stroke continues if the cursor leaves the canvas mid-drag — this also subsumes the previous `onMouseLeave={handleEnd}` behavior, replacing it with the more standard "release-to-end" pattern.
- JSX swaps `onMouse* + onTouch*` for `onPointer{Down,Move,Up,Cancel}`.

## Test plan

- [ ] Draw on the canvas with a regular mouse — produces the same shapes as before; default heart and custom drawings both animate correctly.
- [ ] If you have a pen / drawing tablet, draw a curved stroke quickly — the captured shape should preserve more curvature detail than before (sub-pixel jitter is still filtered by the `≥1px` rule).
- [ ] Drag a stroke off the canvas and back — the stroke continues (pointer capture), instead of ending as it did previously.
- [ ] Touch drawing on mobile still works.