### PR TITLE
Fix corrupted resolved URL in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8852,7 +8852,7 @@
     },
     "node_modules/cssnano-preset-advanced": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-university/-/cssnano-preset-advanced-6.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-6.1.2.tgz",
       "integrity": "sha512-Nhao7eD8ph2DoHolEzQs5CfRpiEP0xa1HBdnFZ82kvqdmbwVBUr2r1QuQ4t1pi+D1ZpqpcO4T+wy/7RxzJ/WPQ==",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- `package-lock.json` had one corrupted `resolved` URL pointing at the non-existent package `cssnano-preset-university` instead of `cssnano-preset-advanced`, causing `npm ci` in GitHub Actions to fail with a 404 and breaking the deploy.
- Only the URL path was wrong — the filename and the `integrity` hash already matched the real `cssnano-preset-advanced@6.1.2` tarball, so a targeted URL fix is sufficient (no version bump, no full lockfile regeneration).

## Test plan
- [x] `npm ci` succeeds locally (1544 packages installed, integrity verified)
- [ ] GitHub Actions deploy workflow passes on this branch

## Note for reviewer
Only one occurrence of "university" existed in the entire lockfile, and only the URL path segment was changed (filename + integrity hash untouched). The corruption pattern is unusual — worth keeping an eye on whether any local tooling/editor is munging the lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)