### PR TITLE
Unify responsive design for custom page titles

### DIFF
--- a/src/components/laikit/Page/styles.module.css
+++ b/src/components/laikit/Page/styles.module.css
@@ -1,17 +1,17 @@
 .headerSection {
   background-color: var(--ifm-background-color);
   border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  padding: 4rem 0;
+  padding: clamp(2rem, 5vw, 4rem) 0;
 }
 
 .headerInner {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 2rem;
+  padding: 0 clamp(1rem, 3vw, 2rem);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 3rem;
+  gap: clamp(1.5rem, 3vw, 3rem);
 }
 
 .headerContent {
@@ -20,7 +20,7 @@
 }
 
 .mainTitle {
-  font-size: 3rem;
+  font-size: clamp(2rem, 4vw + 1rem, 3rem);
   margin: 0 0 1rem 0;
   color: var(--ifm-font-color-base);
   line-height: 1.2;
@@ -32,7 +32,7 @@
 }
 
 .mainDescription {
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 0.5vw + 0.9rem, 1.2rem);
   color: var(--ifm-color-emphasis-700);
   margin: 0;
   line-height: 1.6;
@@ -42,6 +42,5 @@
   .headerInner {
     flex-direction: column;
     align-items: flex-start;
-    gap: 2rem;
   }
 }

--- a/src/pages/blog/moments/styles.module.css
+++ b/src/pages/blog/moments/styles.module.css
@@ -2,14 +2,15 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 1rem;
+  gap: clamp(0.5rem, 2vw, 1rem);
+  padding: clamp(0.75rem, 2vw, 1rem);
 
   background-color: var(--ifm-color-primary);
   color: #ffffff;
   border-radius: 8px;
 }
 
-@media (max-width: 576px) {
+@media (max-width: 768px) {
   .headerSection {
     flex-direction: column;
     align-items: flex-start;
@@ -17,18 +18,20 @@
 }
 
 .title {
-  font-size: 2rem;
+  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
   margin: 0;
+  line-height: 1.2;
 }
 
 .description {
+  font-size: clamp(0.9rem, 0.3vw + 0.85rem, 1rem);
   font-weight: 700;
   opacity: 0.8;
   margin: 0;
 }
 
 .momentCount {
-  font-size: 1.2rem;
+  font-size: clamp(1rem, 0.5vw + 0.9rem, 1.2rem);
   font-weight: 700;
   opacity: 0.8;
 }


### PR DESCRIPTION
## Summary
- Replace the fixed `3rem` font-size on the shared `PageTitle` (used by Settings, Resources, Friends, Travel) with `clamp(2rem, 4vw + 1rem, 3rem)` so titles fluidly scale from 32px on mobile to 48px on desktop.
- Make the surrounding `headerSection` padding, `headerInner` padding, and gap fluid via `clamp()` so the header doesn't feel oversized on small screens.
- Apply the same fluid-typography treatment to the standalone Moments page title and align its stacking breakpoint with the shared `768px` breakpoint (was `576px`).

## Why
Previously the page titles never shrank — `3rem` (48px) on a 375px-wide phone could push layout, and the Moments page used a different breakpoint and a different scale. This unifies the responsive behavior across all custom pages.

## Verified
| Viewport | Settings title | Settings description |
|---|---|---|
| 1280px desktop | 48px | 19.2px |
| 768px tablet | 46.7px | 18.2px |
| 375px mobile | 32px | 16.3px |

Visually checked Settings, Friends, and Moments at desktop, tablet, and mobile widths via dev server.

## Test plan
- [ ] Visit `/settings`, `/resources`, `/friends`, `/travel` at desktop / tablet / mobile widths — title and description scale smoothly, header stacks vertically below 768px.
- [ ] Visit `/blog/moments` at desktop / mobile — title scales between 24–32px, header stacks below 768px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)