### PR TITLE
Drop color fallbacks from theme-variable usage

### DIFF
--- a/src/components/laikit/GitHub/styles.module.css
+++ b/src/components/laikit/GitHub/styles.module.css
@@ -8,7 +8,7 @@
 }
 
 .card {
-  color: var(--ifm-font-color-base, #2c2c2c);
+  color: var(--ifm-font-color-base);
 }
 
 .titleBar {
@@ -19,10 +19,7 @@
   gap: 0.25rem 0.5rem;
   margin-bottom: 0.5rem;
   padding-right: 2rem;
-  color: var(
-    --ifm-heading-color,
-    var(--ifm-color-emphasis-900, var(--ifm-font-color-base, #111))
-  );
+  color: var(--ifm-heading-color);
   font-size: 1.25rem;
   font-weight: 500;
 }
@@ -68,7 +65,7 @@
   width: 1.5rem;
   height: 1.5rem;
   border-radius: 50%;
-  background-color: var(--ifm-color-primary, #0ea5e9);
+  background-color: var(--ifm-color-primary);
   background-size: cover;
 }
 
@@ -77,7 +74,7 @@
   font-size: 1rem;
   font-weight: 300;
   line-height: 1.5rem;
-  color: var(--ifm-font-color-base, #2c2c2c);
+  color: var(--ifm-font-color-base);
   overflow-wrap: anywhere;
 }
 
@@ -86,7 +83,7 @@
   flex-flow: row wrap;
   align-items: center;
   gap: 0.4rem 1.25rem;
-  color: var(--ifm-font-color-secondary, #666);
+  color: var(--ifm-font-color-secondary);
 }
 
 .language {
@@ -96,7 +93,7 @@
   font-size: 0.875rem;
   opacity: 0.9;
   border-radius: 0.4rem;
-  background: var(--ifm-badge-background-color, rgba(127, 127, 127, 0.1));
+  background: var(--ifm-color-emphasis-200);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -205,7 +202,7 @@
 .loading .description,
 .loading .infoBar,
 .loading .avatar {
-  background-color: var(--ifm-font-color-base, #2c2c2c);
+  background-color: var(--ifm-font-color-base);
   color: transparent;
   opacity: 0.5;
   user-select: none;
@@ -221,7 +218,7 @@
 .errorText {
   margin-top: 0.25rem;
   font-size: 0.75rem;
-  color: var(--ifm-color-danger, #ff4d4f);
+  color: var(--ifm-color-danger);
 }
 
 @keyframes pulsate {

--- a/src/theme/Root/CookieConsent/styles.module.css
+++ b/src/theme/Root/CookieConsent/styles.module.css
@@ -74,7 +74,7 @@ html[data-theme='dark'] .card {
 .accept {
   background: var(--ifm-color-primary);
   border: 1px solid var(--ifm-color-primary);
-  color: var(--ifm-button-color, #fff);
+  color: var(--ifm-button-color);
 }
 
 .accept:hover {


### PR DESCRIPTION
## Summary

- Strip the defensive `#hex` fallbacks from `var(--ifm-*, #hex)` calls in [GitHub card styles](src/components/laikit/GitHub/styles.module.css) and the [CookieConsent accept button](src/theme/Root/CookieConsent/styles.module.css). Every variable used here is defined at root scope in Infima's `default.css` and `default-dark.css` (verified in `node_modules/infima`), so the second argument never fires — it just hardcodes a stale color that can drift from the theme.
- Replace `var(--ifm-badge-background-color, rgba(127,127,127,0.1))` on the language pill with `var(--ifm-color-emphasis-200)`. `--ifm-badge-background-color` exists but defaults to `inherit` outside `.badge` elements, so the rgba fallback was the only thing supplying a real color there.

## Why

Working toward fewer, more precise accent colors site-wide. Removing the fallbacks ensures the GitHub card and cookie banner stay in sync with the active theme, and removes a small set of hardcoded hex values from the codebase.

## Variables verified (Infima `default.css` / `default-dark.css`)

| Variable | Resolved at root |
|---|---|
| `--ifm-color-primary` | `#1d9bf0` (overridden in `custom.css`) |
| `--ifm-color-danger` | `#fa383e` |
| `--ifm-color-emphasis-200` / `-900` | gray scale |
| `--ifm-font-color-base` / `-secondary` | content / content-secondary |
| `--ifm-heading-color` | `inherit` (intentional) |
| `--ifm-button-color` | `var(--ifm-font-color-base-inverse)` |

## Test plan

- [ ] Visit a docs page with a `<GitHub>` card (e.g. `/docs/project/code-comparator`) and confirm title, description, info bar, avatar, language pill, and error state still render correctly in both light and dark themes.
- [ ] Trigger the cookie banner and confirm the "accept" button text remains legible against the primary background in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)