### PR TITLE
Rework Settings page with Slider, Language, and shared theme color

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -813,10 +813,10 @@
     "message": "重置"
   },
   "pages.settings.item.font.title": {
-    "message": "字体大小"
+    "message": "排版"
   },
   "pages.settings.item.font.description": {
-    "message": "调整界面文字大小"
+    "message": "调整文字大小与行间距"
   },
   "pages.settings.item.experimental.title": {
     "message": "实验性功能"
@@ -839,8 +839,11 @@
   "pages.settings.item.theme.option.dark": {
     "message": "深色模式"
   },
-  "pages.settings.item.font.current": {
-    "message": "当前：{size}px"
+  "pages.settings.item.font.size.current": {
+    "message": "字体大小：{size}px"
+  },
+  "pages.settings.item.font.lineheight.current": {
+    "message": "行间距：{value}"
   },
   "pages.settings.item.experimental.option.originalLayout": {
     "message": "原版布局"
@@ -973,5 +976,14 @@
   },
   "data.devices.powerbeats-pro.spec": {
     "message": "极速黑 / H2"
+  },
+  "pages.settings.item.color.picker": {
+    "message": "选择颜色"
+  },
+  "pages.settings.item.language.title": {
+    "message": "语言"
+  },
+  "pages.settings.item.language.description": {
+    "message": "切换界面语言"
   }
 }

--- a/src/components/laikit/Slider/index.tsx
+++ b/src/components/laikit/Slider/index.tsx
@@ -1,0 +1,77 @@
+import React, { type ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+export interface SliderTick {
+  value: number;
+  label: ReactNode;
+}
+
+interface SliderProps {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  ticks?: SliderTick[];
+  onChange: (value: number) => void;
+  onCommit?: (value: number) => void;
+  className?: string;
+  'aria-label'?: string;
+}
+
+export default function Slider({
+  value,
+  min,
+  max,
+  step = 1,
+  ticks,
+  onChange,
+  onCommit,
+  className,
+  'aria-label': ariaLabel,
+}: SliderProps) {
+  const progress = ((value - min) / (max - min)) * 100;
+
+  const handleCommit = (e: React.SyntheticEvent<HTMLInputElement>) => {
+    if (!onCommit) return;
+    onCommit(parseFloat((e.target as HTMLInputElement).value));
+  };
+
+  return (
+    <div className={clsx(styles.slider, className)}>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        aria-label={ariaLabel}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        onPointerUp={handleCommit}
+        onKeyUp={handleCommit}
+        className={styles.input}
+        style={{ '--slider-progress': `${progress}%` } as React.CSSProperties}
+      />
+      {ticks && ticks.length > 0 && (
+        <div className={styles.ticks}>
+          {ticks.map((tick) => {
+            const ratio = (tick.value - min) / (max - min);
+            return (
+              <span
+                key={tick.value}
+                className={styles.tick}
+                style={
+                  {
+                    '--slider-tick-ratio': ratio,
+                  } as React.CSSProperties
+                }
+              >
+                {tick.label}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/laikit/Slider/styles.module.css
+++ b/src/components/laikit/Slider/styles.module.css
@@ -1,0 +1,74 @@
+.slider {
+  --slider-thumb-size: 16px;
+  --slider-track-height: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  width: 100%;
+}
+
+.input {
+  --slider-progress: 50%;
+  width: 100%;
+  height: var(--slider-track-height);
+  margin: 0;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: linear-gradient(
+    to right,
+    var(--ifm-color-primary) 0%,
+    var(--ifm-color-primary) var(--slider-progress),
+    var(--ifm-color-emphasis-200) var(--slider-progress),
+    var(--ifm-color-emphasis-200) 100%
+  );
+  -webkit-appearance: none;
+  appearance: none;
+  outline: none;
+  cursor: pointer;
+}
+
+.input::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background: white;
+  border: 2px solid var(--ifm-color-primary);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.input::-webkit-slider-thumb:active {
+  transform: scale(0.9);
+}
+
+.input::-moz-range-thumb {
+  width: var(--slider-thumb-size);
+  height: var(--slider-thumb-size);
+  border-radius: 50%;
+  background: white;
+  border: 2px solid var(--ifm-color-primary);
+  cursor: pointer;
+}
+
+.ticks {
+  position: relative;
+  height: 0.78rem;
+  font-size: 0.78rem;
+  line-height: 1;
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+  font-feature-settings: 'tnum';
+}
+
+.tick {
+  position: absolute;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  left: calc(
+    var(--slider-thumb-size) / 2 +
+      var(--slider-tick-ratio) * (100% - var(--slider-thumb-size))
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,6 +16,7 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 
   --global-font-size: 16px;
+  --global-line-height: 1.65;
 }
 
 [data-theme='dark'] {
@@ -68,6 +69,7 @@ html,
 article,
 .markdown {
   font-size: var(--global-font-size);
+  line-height: var(--global-line-height);
 }
 
 .katex-display {

--- a/src/data/settings.tsx
+++ b/src/data/settings.tsx
@@ -1,12 +1,16 @@
 export const SETTINGS_PRESET_COLOR_LIST = [
-  '#1d9bf0',
-  '#7f52f6',
-  '#e557bd',
-  '#df5634',
-  '#f1a255',
-  '#f7cb5d',
-  '#83d37f',
-  '#7dd5cc',
+  '#1d9bf0', // blue       205°
+  '#6366f1', // indigo     239°
+  '#a855f7', // purple     270°
+  '#d946ef', // fuchsia    291°
+  '#ec4899', // pink        330°
+  '#ef4444', // red          0°
+  '#f97316', // orange      24°
+  '#eab308', // yellow      46°
+  '#84cc16', // lime        84°
+  '#22c55e', // green       142°
+  '#14b8a6', // teal        174°
+  '#06b6d4', // cyan        190°
 ];
 
 export const SETTINGS_EXPERIMENTAL_DEFAULT = {

--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -9,7 +9,7 @@ import {
 } from '@site/src/utils/colorUtils';
 
 export function useThemeColors(isDarkTheme: boolean) {
-  const storage = getThemeStorage(isDarkTheme);
+  const storage = getThemeStorage();
   const defaults = getThemeDefaults(isDarkTheme);
 
   const [colorState, setColorState] = useState<ColorState>(() => {
@@ -33,7 +33,7 @@ export function useThemeColors(isDarkTheme: boolean) {
   const [inputColor, setInputColor] = useState(colorState.baseColor);
 
   useEffect(() => {
-    const newStorage = getThemeStorage(isDarkTheme);
+    const newStorage = getThemeStorage();
     const newDefaults = getThemeDefaults(isDarkTheme);
     const storedValues = JSON.parse(
       newStorage.get() ?? '{}'
@@ -49,7 +49,7 @@ export function useThemeColors(isDarkTheme: boolean) {
 
   useEffect(() => {
     updateDOMColors(colorState, isDarkTheme);
-    const storage = getThemeStorage(isDarkTheme);
+    const storage = getThemeStorage();
     storage.set(JSON.stringify(colorState));
   }, [colorState, isDarkTheme]);
 

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -9,14 +9,16 @@ import Segmented, {
   type SegmentedItem,
 } from '@site/src/components/laikit/Segmented';
 import Switch from '@site/src/components/laikit/Switch';
+import Slider from '@site/src/components/laikit/Slider';
 import DataCard from '@site/src/components/laikit/DataCard';
 import {
   SETTINGS_EXPERIMENTAL_DEFAULT,
   SETTINGS_PRESET_COLOR_LIST,
 } from '@site/src/data/settings';
 import { useColorMode } from '@docusaurus/theme-common';
+import { useAlternatePageUtils } from '@docusaurus/theme-common/internal';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { usePersistentState } from '@site/src/hooks/usePersistentState';
-import { getAdjustedColors } from '@site/src/utils/colorUtils';
 import { useThemeColors } from '@site/src/hooks/useThemeColors';
 import { Icon } from '@iconify/react';
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
@@ -109,18 +111,35 @@ function AccentColor() {
     >
       <div className={styles.colorGeneratorContainer}>
         <div className={styles.colorInputContainer}>
-          <input
-            type="text"
-            value={inputColor}
-            onChange={(e) => updateColor(e.target.value)}
-            className={styles.textColorInput}
-          />
-          <input
-            type="color"
-            value={colorState.baseColor}
-            onChange={(e) => updateColor(e.target.value)}
-            className={styles.colorPickerInput}
-          />
+          <label className={styles.colorField}>
+            <input
+              type="color"
+              value={colorState.baseColor}
+              onChange={(e) => updateColor(e.target.value)}
+              className={styles.colorPickerInput}
+              aria-label={translate({
+                id: 'pages.settings.item.color.picker',
+                message: 'Pick color',
+              })}
+            />
+            <input
+              type="text"
+              value={inputColor}
+              onChange={(e) => updateColor(e.target.value)}
+              className={styles.textColorInput}
+              size={8}
+            />
+          </label>
+          <button
+            type="button"
+            className={styles.resetButton}
+            onClick={resetColors}
+          >
+            {translate({
+              id: 'pages.settings.item.color.reset',
+              message: 'Reset',
+            })}
+          </button>
         </div>
         <div className={styles.presetColors}>
           {SETTINGS_PRESET_COLOR_LIST.map((color) => (
@@ -134,37 +153,14 @@ function AccentColor() {
             />
           ))}
         </div>
-        <div className={styles.colorPreviewContainer}>
-          <div
-            className={styles.colorPreview}
-            style={{
-              background: `linear-gradient(to right, ${getAdjustedColors(
-                colorState.shades,
-                colorState.baseColor
-              )
-                .sort((a, b) => a.displayOrder - b.displayOrder)
-                .map((value) => value.hex)
-                .join(', ')})`,
-            }}
-          />
-          <button
-            type="button"
-            className={styles.resetButton}
-            onClick={resetColors}
-          >
-            {translate({
-              id: 'pages.settings.item.color.reset',
-              message: 'Reset',
-            })}
-          </button>
-        </div>
       </div>
     </IconCard>
   );
 }
 
-function FontSize() {
+function Typography() {
   const [fontSize, setFontSize] = useState<number>(16);
+  const [lineHeight, setLineHeight] = useState<number>(1.65);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -172,6 +168,13 @@ function FontSize() {
     const initialSize = savedSize ? parseInt(savedSize, 10) : 16;
     setFontSize(initialSize);
     root.style.setProperty('--global-font-size', `${initialSize}px`);
+
+    const savedLineHeight = localStorage.getItem('global-line-height');
+    const initialLineHeight = savedLineHeight
+      ? parseFloat(savedLineHeight)
+      : 1.65;
+    setLineHeight(initialLineHeight);
+    root.style.setProperty('--global-line-height', `${initialLineHeight}`);
   }, []);
 
   const commitSize = (size: number) => {
@@ -182,53 +185,81 @@ function FontSize() {
     localStorage.setItem('global-font-size', size.toString());
   };
 
-  const min = 12;
-  const max = 20;
-  const progress = ((fontSize - min) / (max - min)) * 100;
+  const commitLineHeight = (value: number) => {
+    const rounded = Math.round(value * 20) / 20;
+    document.documentElement.style.setProperty(
+      '--global-line-height',
+      `${rounded}`
+    );
+    localStorage.setItem('global-line-height', rounded.toString());
+  };
+
+  const sizeMin = 12;
+  const sizeMax = 20;
+  const lineHeightMin = 1.3;
+  const lineHeightMax = 2.0;
 
   return (
     <IconCard
       title={translate({
         id: 'pages.settings.item.font.title',
-        message: 'Font Size',
+        message: 'Typography',
       })}
       description={translate({
         id: 'pages.settings.item.font.description',
-        message: 'Adjust interface text size',
+        message: 'Adjust text size and line spacing',
       })}
       icon="lucide:type"
       bodyAlign="bottom"
     >
-      <div className={styles.sliderContainer}>
-        <span className={styles.sliderLabel}>
-          {translate(
-            {
-              id: 'pages.settings.item.font.current',
-              message: 'Current: {size}px',
-            },
-            { size: fontSize }
-          )}
-        </span>
-        <input
-          type="range"
-          min={min}
-          max={max}
-          step={1}
-          value={fontSize}
-          onChange={(e) => setFontSize(parseInt(e.target.value, 10))}
-          onPointerUp={(e) =>
-            commitSize(parseInt((e.target as HTMLInputElement).value, 10))
-          }
-          onKeyUp={(e) =>
-            commitSize(parseInt((e.target as HTMLInputElement).value, 10))
-          }
-          className={styles.slider}
-          style={{ '--slider-progress': `${progress}%` } as React.CSSProperties}
-        />
-        <div className={styles.sliderTicks}>
-          <span>12px</span>
-          <span>16px</span>
-          <span>20px</span>
+      <div className={styles.sliderGroup}>
+        <div className={styles.sliderContainer}>
+          <span className={styles.sliderLabel}>
+            {translate(
+              {
+                id: 'pages.settings.item.font.size.current',
+                message: 'Font Size: {size}px',
+              },
+              { size: fontSize }
+            )}
+          </span>
+          <Slider
+            value={fontSize}
+            min={sizeMin}
+            max={sizeMax}
+            step={1}
+            onChange={setFontSize}
+            onCommit={commitSize}
+            ticks={[
+              { value: 12, label: '12px' },
+              { value: 16, label: '16px' },
+              { value: 20, label: '20px' },
+            ]}
+          />
+        </div>
+        <div className={styles.sliderContainer}>
+          <span className={styles.sliderLabel}>
+            {translate(
+              {
+                id: 'pages.settings.item.font.lineheight.current',
+                message: 'Line Height: {value}',
+              },
+              { value: lineHeight.toFixed(2) }
+            )}
+          </span>
+          <Slider
+            value={lineHeight}
+            min={lineHeightMin}
+            max={lineHeightMax}
+            step={0.05}
+            onChange={(v) => setLineHeight(Math.round(v * 20) / 20)}
+            onCommit={commitLineHeight}
+            ticks={[
+              { value: 1.3, label: '1.30' },
+              { value: 1.65, label: '1.65' },
+              { value: 2.0, label: '2.00' },
+            ]}
+          />
         </div>
       </div>
     </IconCard>
@@ -337,6 +368,7 @@ function QuickActions() {
   function handleReset() {
     localStorage.removeItem('theme');
     localStorage.removeItem('global-font-size');
+    localStorage.removeItem('global-line-height');
     localStorage.removeItem('settings-notifications');
     localStorage.removeItem('settings-experimental');
     window.location.reload();
@@ -399,7 +431,7 @@ function SettingsHeader() {
     <PageHeader>
       <PageTitle title={MODIFICATION} description={DESCRIPTION} />
       <DataCard
-        value={5}
+        value={6}
         label={translate({
           id: 'pages.settings.datacard.label',
           message: 'Settings',
@@ -410,12 +442,53 @@ function SettingsHeader() {
   );
 }
 
+function LanguageSettings() {
+  const {
+    i18n: { currentLocale, locales, localeConfigs },
+  } = useDocusaurusContext();
+  const alternatePageUtils = useAlternatePageUtils();
+
+  const items: SegmentedItem<string>[] = locales.map((locale) => ({
+    value: locale,
+    label: localeConfigs[locale].label,
+    icon: 'lucide:languages',
+  }));
+
+  return (
+    <IconCard
+      title={translate({
+        id: 'pages.settings.item.language.title',
+        message: 'Language',
+      })}
+      description={translate({
+        id: 'pages.settings.item.language.description',
+        message: 'Switch the interface language',
+      })}
+      icon="lucide:languages"
+      bodyAlign="bottom"
+    >
+      <Segmented<string>
+        value={currentLocale}
+        items={items}
+        onChange={(locale) => {
+          if (locale === currentLocale) return;
+          window.location.href = alternatePageUtils.createUrl({
+            locale,
+            fullyQualified: false,
+          });
+        }}
+      />
+    </IconCard>
+  );
+}
+
 function SettingsContainer() {
   return (
     <div className={styles.container}>
       <ThemeSettings />
       <AccentColor />
-      <FontSize />
+      <LanguageSettings />
+      <Typography />
       <ExperimentalFeatures />
       <QuickActions />
     </div>

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -13,8 +13,8 @@
 
 .container {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-template-areas: 'a1 a2 a2' 'a3 a4 a5';
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-areas: 'a1 a2 a3' 'a4 a5 a6';
   gap: 1.5rem;
 
   width: 100%;
@@ -27,8 +27,8 @@
 
 @media (max-width: 1199px) {
   .container {
-    grid-template-columns: 1fr 1fr;
-    grid-template-areas: 'a1 a3' 'a2 a2' 'a4 a5';
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas: 'a1 a4' 'a2 a3' 'a5 a6';
     padding: 1.5rem;
   }
 }
@@ -36,7 +36,7 @@
 @media (max-width: 768px) {
   .container {
     grid-template-columns: 1fr;
-    grid-template-areas: 'a1' 'a2' 'a3' 'a4' 'a5';
+    grid-template-areas: 'a1' 'a2' 'a3' 'a4' 'a5' 'a6';
     padding: 1rem;
   }
 }
@@ -56,6 +56,9 @@
 .container > :nth-child(5) {
   grid-area: a5;
 }
+.container > :nth-child(6) {
+  grid-area: a6;
+}
 
 /* Color generator */
 
@@ -72,42 +75,70 @@
   align-items: center;
 }
 
-.textColorInput {
+.colorField {
+  display: flex;
+  align-items: center;
   flex: 1;
-  padding: 0.5rem;
-  border-radius: 12px;
+  min-width: 0;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border-radius: 10px;
   border: 2px solid var(--ifm-color-emphasis-300);
-  font-size: 0.9rem;
-  font-family: monospace;
+  cursor: text;
+  transition: border-color 0.2s ease;
 }
 
-.textColorInput:focus {
+.colorField:focus-within {
   border-color: var(--ifm-color-primary);
+}
+
+.textColorInput {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
   outline: none;
+  font-size: 0.9rem;
+  font-family: monospace;
+  color: inherit;
 }
 
 .colorPickerInput {
-  width: 40px;
-  height: 40px;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
   border: none;
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
   background: none;
   padding: 0;
 }
 
-.presetColors {
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
+.colorPickerInput::-webkit-color-swatch-wrapper {
+  padding: 0;
 }
 
-@media (max-width: 576px) {
+.colorPickerInput::-webkit-color-swatch {
+  border: none;
+  border-radius: 6px;
+}
+
+.colorPickerInput::-moz-color-swatch {
+  border: none;
+  border-radius: 6px;
+}
+
+.presetColors {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+@media (max-width: 400px) {
   .presetColors {
-    display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0.75rem;
-    justify-items: center;
   }
 }
 
@@ -124,22 +155,9 @@
   transform: scale(1.1);
 }
 
-.colorPreviewContainer {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.colorPreview {
-  flex: 1;
-  height: 30px;
-  border: 2px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
-}
-
 .resetButton {
   flex-shrink: 0;
-  height: 30px;
+  height: 40px;
   padding: 0 0.85rem;
   display: inline-flex;
   align-items: center;
@@ -162,13 +180,18 @@
   color: var(--ifm-color-primary);
 }
 
-/* Font-size slider */
+/* Typography sliders */
 
-.sliderContainer {
-  --slider-thumb-size: 20px;
+.sliderGroup {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0.75rem;
+}
+
+.sliderContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .sliderLabel {
@@ -177,84 +200,6 @@
   align-items: center;
   font-size: 0.9rem;
   color: var(--ifm-color-emphasis-700);
-}
-
-.slider {
-  --slider-progress: 50%;
-  width: 100%;
-  height: 6px;
-  margin: 0;
-  padding: 0;
-  border: 0;
-  border-radius: 999px;
-  background: linear-gradient(
-    to right,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary) var(--slider-progress),
-    var(--ifm-color-emphasis-200) var(--slider-progress),
-    var(--ifm-color-emphasis-200) 100%
-  );
-  -webkit-appearance: none;
-  appearance: none;
-  outline: none;
-  cursor: pointer;
-}
-
-.slider::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: var(--slider-thumb-size);
-  height: var(--slider-thumb-size);
-  border-radius: 50%;
-  background: white;
-  border: 3px solid var(--ifm-color-primary);
-  cursor: pointer;
-  transition: transform 0.2s ease;
-}
-
-.slider::-webkit-slider-thumb:hover {
-  transform: scale(1.1);
-}
-
-.slider::-webkit-slider-thumb:hover:active {
-  transform: scale(1);
-}
-
-.slider::-moz-range-thumb {
-  width: var(--slider-thumb-size);
-  height: var(--slider-thumb-size);
-  border-radius: 50%;
-  background: white;
-  border: 3px solid var(--ifm-color-primary);
-  cursor: pointer;
-}
-
-.sliderTicks {
-  position: relative;
-  height: 0.78rem;
-  font-size: 0.78rem;
-  line-height: 1;
-  color: var(--ifm-color-emphasis-600);
-  font-weight: 500;
-  font-feature-settings: 'tnum';
-}
-
-.sliderTicks > span {
-  position: absolute;
-  transform: translateX(-50%);
-  white-space: nowrap;
-}
-
-.sliderTicks > span:nth-child(1) {
-  left: calc(var(--slider-thumb-size) / 2);
-}
-
-.sliderTicks > span:nth-child(2) {
-  left: 50%;
-}
-
-.sliderTicks > span:nth-child(3) {
-  left: calc(100% - var(--slider-thumb-size) / 2);
 }
 
 /* Experimental toggles */

--- a/src/theme/Root/CookieConsent/styles.module.css
+++ b/src/theme/Root/CookieConsent/styles.module.css
@@ -72,14 +72,14 @@ html[data-theme='dark'] .card {
 }
 
 .accept {
-  background: var(--ifm-color-primary);
-  border: 1px solid var(--ifm-color-primary);
-  color: var(--ifm-button-color);
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
 }
 
 .accept:hover {
-  background: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-emphasis-500);
+  background: var(--ifm-color-emphasis-100);
 }
 
 .button:focus-visible {

--- a/src/utils/colorUtils.ts
+++ b/src/utils/colorUtils.ts
@@ -73,10 +73,8 @@ const THEME_CONFIG = {
 } as const;
 
 // sessionStorage so customizations reset the next time users visit the site.
-const lightStorage = createStorageSlot('ifm-theme-colors-light', {
-  persistence: 'sessionStorage',
-});
-const darkStorage = createStorageSlot('ifm-theme-colors-dark', {
+// Light and dark mode share a single accent color, so they share storage too.
+const themeStorage = createStorageSlot('ifm-theme-colors', {
   persistence: 'sessionStorage',
 });
 
@@ -85,8 +83,8 @@ export function getThemeDefaults(isDarkTheme: boolean) {
   return THEME_CONFIG[theme];
 }
 
-export function getThemeStorage(isDarkTheme: boolean) {
-  return isDarkTheme ? darkStorage : lightStorage;
+export function getThemeStorage() {
+  return themeStorage;
 }
 
 export function getAdjustedColors(


### PR DESCRIPTION
## Summary

- Add a reusable `laikit/Slider` (label ticks auto-positioned by value).
- Expand the Font Size card into **Typography** (font size + line height; line height range 1.30–2.00, step 0.05, default 1.65 — step-aligned so the thumb and progress fill stay in sync).
- Replace the temporary placeholder with a **Language** card driven by Docusaurus i18n (`useAlternatePageUtils` + existing `Segmented`).
- Rework **Accent Color**: combined swatch + hex field, 12-color preset palette sorted by hue (responsive 2×6, falls back to 3×4 ≤400px), inline Reset; `size={8}` on the hex input so the column can shrink past the previous ~357px min-content bottleneck.
- Equalize grid columns with `minmax(0, 1fr)` and switch to a 6-cell layout across all breakpoints.
- Share a single `sessionStorage` slot between light/dark accents so the picked color survives theme switches.
- Cookie consent **Accept** styled like **Reject** (transparent + neutral border) instead of the primary color.

## Why

- The original page had a plain `<input type="range">` and partial mobile layout; pulling it into a laikit component makes it reusable and easier to style.
- Settings page had an obvious empty slot after Accent Color was narrowed; Language was the most natural fit and Docusaurus already exposes everything needed (~25 lines of glue).
- Light/dark accent colors used to be stored separately, which surprised users (pick a color in light mode, dark mode reverts on switch).
- The 1.65 default for Line Height was outside the slider's step grid and the browser snapped the thumb to 1.7, producing a visible misalignment with the progress fill.

## Notes for reviewer

- `useAlternatePageUtils` is imported from `@docusaurus/theme-common/internal` — same path Docusaurus's own `LocaleDropdownNavbarItem` uses.
- Production build was run during development (`npm run build`) and both `en` + `zh-Hans` locales build successfully.
- Visual / responsive checks were done in the dev preview at desktop, ~390px, and 200–300px widths to confirm the new min-content limits.

## Test plan

- [ ] `/settings/` renders 6 cards with equal column widths; placeholder slot is replaced by the Language card.
- [ ] Dragging Font Size and Line Height sliders updates the global CSS vars; thumb stays aligned with the filled track at every step.
- [ ] Picking an accent color in light mode persists when switching to dark mode (and vice versa).
- [ ] Switching language navigates between `/settings/` and `/zh-Hans/settings/` correctly.
- [ ] At ≤400px the preset color grid becomes 3×4; at default size it stays 2×6.
- [ ] Cookie consent banner's Accept and Reject buttons share the same neutral styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)