### PR TITLE
Keep background per-theme when sharing accent color

### DIFF
--- a/src/hooks/useThemeColors.ts
+++ b/src/hooks/useThemeColors.ts
@@ -25,7 +25,10 @@ export function useThemeColors(isDarkTheme: boolean) {
     ) as Partial<ColorState>;
     return {
       baseColor: storedValues.baseColor ?? defaults.primary,
-      background: storedValues.background ?? defaults.background,
+      // Background is theme-specific (white in light, dark in dark) and not
+      // user-configurable, so always derive it from the active theme rather
+      // than the shared storage slot.
+      background: defaults.background,
       shades: storedValues.shades ?? COLOR_SHADES,
     };
   });
@@ -40,7 +43,7 @@ export function useThemeColors(isDarkTheme: boolean) {
     ) as Partial<ColorState>;
     const newState = {
       baseColor: storedValues.baseColor ?? newDefaults.primary,
-      background: storedValues.background ?? newDefaults.background,
+      background: newDefaults.background,
       shades: storedValues.shades ?? COLOR_SHADES,
     };
     setColorState(newState);


### PR DESCRIPTION
## Summary

Follow-up fix to #23. The shared `sessionStorage` slot was carrying `background: #ffffff` from light mode into dark mode, so `updateDOMColors` emitted a white background override on the dark theme.

`background` isn't user-configurable on the Settings page — only the accent color is. So the value should always come from the active theme's defaults, not the shared slot.

## Changes

- `src/hooks/useThemeColors.ts`: in both state constructions (initial `useState` and `useEffect` on `[isDarkTheme]`), set `background` to `defaults.background` and stop reading it from storage.

## Test plan

- [ ] Open `/settings/`, pick a non-default accent color in light mode, switch to dark mode → background is dark, accent color is preserved.
- [ ] Switch back to light mode → background is white, same accent stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)