### PR TITLE
Polish UI controls and round out Original Layout coverage

### DIFF
--- a/src/data/changelog.tsx
+++ b/src/data/changelog.tsx
@@ -9,7 +9,7 @@ interface ChangelogItem {
 export const CHANGELOG_LIST: ChangelogItem[] = [
   {
     date: '2026-04-28',
-    type: 'add',
+    type: 'added',
     content: '主页 <b>Lorenz Attractor</b> 组件',
   },
   {

--- a/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
+++ b/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
-import { Icon } from '@iconify/react';
 import { translate } from '@docusaurus/Translate';
+import Slider from '@site/src/components/laikit/Slider';
 import styles from './styles.module.css';
 
 const TWO_PI = 2 * Math.PI;
@@ -137,22 +137,20 @@ function ParamSlider({
   precision,
   onChange,
 }: SliderProps) {
-  const pct = ((value - min) / (max - min)) * 100;
   return (
     <div className={styles.slider}>
       <div className={styles.sliderHead}>
         <span className={styles.sliderLabel}>{label}</span>
         <span className={styles.sliderValue}>{value.toFixed(precision)}</span>
       </div>
-      <input
-        type="range"
+      <Slider
+        value={value}
         min={min}
         max={max}
         step={step}
-        value={value}
-        onChange={(e) => onChange(parseFloat(e.target.value))}
-        className={styles.sliderInput}
-        style={{ ['--lz-slider-fill' as string]: `${pct}%` }}
+        onChange={onChange}
+        aria-label={label}
+        className={styles.sliderControl}
       />
     </div>
   );
@@ -429,8 +427,7 @@ export default function LorenzAttractorCanvas() {
           onClick={handleReset}
           aria-label={RESET_LABEL}
         >
-          <Icon icon="lucide:refresh-cw" width={14} height={14} />
-          <span>{RESET_LABEL}</span>
+          {RESET_LABEL}
         </button>
       </div>
     </div>

--- a/src/pages/_components/LorenzAttractor/styles.module.css
+++ b/src/pages/_components/LorenzAttractor/styles.module.css
@@ -65,95 +65,34 @@ html[data-theme='dark'] .canvas {
   color: var(--ifm-color-emphasis-600);
 }
 
-.sliderInput {
-  --lz-slider-fill: 50%;
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 4px;
-  border-radius: 999px;
-  background: linear-gradient(
-    to right,
-    var(--ifm-color-primary) 0%,
-    var(--ifm-color-primary) var(--lz-slider-fill),
-    var(--ifm-color-emphasis-300) var(--lz-slider-fill),
-    var(--ifm-color-emphasis-300) 100%
-  );
-  outline: none;
-  cursor: pointer;
-}
-
-.sliderInput::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--ifm-color-primary);
-  border: 2px solid var(--ifm-card-background-color);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-  cursor: grab;
-  transition: transform 0.15s ease;
-}
-
-.sliderInput::-webkit-slider-thumb:hover {
-  transform: scale(1.15);
-}
-
-.sliderInput::-webkit-slider-thumb:active {
-  cursor: grabbing;
-  transform: scale(1.05);
-}
-
-.sliderInput::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-  background: var(--ifm-color-primary);
-  border: 2px solid var(--ifm-card-background-color);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
-  cursor: grab;
-}
-
-.sliderInput::-moz-range-track {
-  height: 4px;
-  border-radius: 999px;
-  background: transparent;
-}
-
-.sliderInput:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.3);
+.sliderControl {
+  --slider-track-height: 4px;
+  --slider-thumb-size: 14px;
 }
 
 .resetButton {
+  flex-shrink: 0;
+  height: 40px;
+  padding: 0 0.85rem;
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  height: 36px;
-  padding: 0 0.85rem;
-  border-radius: 10px;
+  justify-content: center;
+  background: transparent;
   border: 1px solid var(--ifm-color-emphasis-300);
-  background: var(--ifm-card-background-color);
-  color: var(--ifm-color-emphasis-800);
+  border-radius: 10px;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
   font-size: 0.85rem;
   font-weight: 600;
-  cursor: pointer;
+  letter-spacing: 0.01em;
   transition:
-    color 0.2s ease,
     border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    background 0.2s ease;
+    color 0.2s ease;
 }
 
 .resetButton:hover {
-  color: var(--ifm-color-primary);
   border-color: var(--ifm-color-primary);
-  box-shadow: 0 2px 8px rgba(var(--ifm-color-primary-rgb), 0.15);
-}
-
-.resetButton:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.3);
+  color: var(--ifm-color-primary);
 }
 
 @media (max-width: 500px) {

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -56,9 +56,9 @@
   --nn-neuron-border-default: #94a3b8;
   --nn-neuron-fill-default: #ffffff;
 
-  /* Neuron gray ramp: 0 -> light, 1 -> dark. */
-  --nn-neuron-gray-base: 230;
-  --nn-neuron-gray-multiplier: -195;
+  /* Neuron gray ramp: 0 -> white, 1 -> black. */
+  --nn-neuron-gray-base: 255;
+  --nn-neuron-gray-multiplier: -255;
 
   --nn-connection-negative-rgb: 239, 68, 68;
   --nn-connection-positive-rgb: 59, 130, 246;
@@ -73,8 +73,8 @@
   --nn-stroke-primary: var(--ifm-color-primary);
   --nn-stroke-accent: var(--ifm-color-primary);
 
-  --nn-grid-white: #1e2040;
-  --nn-grid-white-rgb: 30, 32, 64;
+  --nn-grid-white: #000000;
+  --nn-grid-white-rgb: 0, 0, 0;
   --nn-grid-stroke: var(--ifm-color-primary);
   --nn-grid-fill: #ffffff;
 }

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -83,7 +83,7 @@
   gap: 0.5rem;
   padding: 0.25rem;
   border-radius: 10px;
-  border: 2px solid var(--ifm-color-emphasis-300);
+  border: 1px solid var(--ifm-color-emphasis-300);
   cursor: text;
   transition: border-color 0.2s ease;
 }
@@ -163,8 +163,8 @@
   align-items: center;
   justify-content: center;
   background: transparent;
-  border: 2px solid var(--ifm-color-emphasis-300);
-  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
   color: var(--ifm-color-emphasis-700);
   cursor: pointer;
   font-size: 0.85rem;

--- a/src/theme/Blog/Pages/BlogAuthorsListPage/index.tsx
+++ b/src/theme/Blog/Pages/BlogAuthorsListPage/index.tsx
@@ -1,6 +1,8 @@
 import React, { type ReactNode } from 'react';
 import { translate } from '@docusaurus/Translate';
 
+import { useTheme } from '@site/src/hooks/useTheme';
+import BlogAuthorsListPageOriginal from '@theme-original/Blog/Pages/BlogAuthorsListPage';
 import type { Props } from '@theme/Blog/Pages/BlogAuthorsListPage';
 import { BlogCard, TagChipList } from '../../../BlogShared/Components';
 import BlogScaffold from '../../../BlogShared/Scaffold';
@@ -11,7 +13,11 @@ const TITLE = translate({
 });
 const DESCRIPTION = "Authors of lailai's blog";
 
-export default function BlogAuthorsListPage({ authors }: Props): ReactNode {
+export default function BlogAuthorsListPage(props: Props): ReactNode {
+  const { isOriginalLayout } = useTheme();
+  if (isOriginalLayout) return <BlogAuthorsListPageOriginal {...props} />;
+
+  const { authors } = props;
   return (
     <BlogScaffold title={TITLE} description={DESCRIPTION}>
       <BlogCard title={TITLE}>

--- a/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
+++ b/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
@@ -1,8 +1,13 @@
 import React, { type ReactNode } from 'react';
+import { useTheme } from '@site/src/hooks/useTheme';
+import BlogAuthorsPostsPageOriginal from '@theme-original/Blog/Pages/BlogAuthorsPostsPage';
 import type { Props } from '@theme/Blog/Pages/BlogAuthorsPostsPage';
 import PostsListLayout from '../../../BlogShared/PostsListLayout';
 
 export default function BlogAuthorsPostsPage(props: Props): ReactNode {
+  const { isOriginalLayout } = useTheme();
+  if (isOriginalLayout) return <BlogAuthorsPostsPageOriginal {...props} />;
+
   const { author, items, listMetadata } = props;
 
   return (

--- a/src/theme/Root/CookieConsent/styles.module.css
+++ b/src/theme/Root/CookieConsent/styles.module.css
@@ -51,7 +51,7 @@ html[data-theme='dark'] .card {
   border-radius: 999px;
   padding: 0.4rem 1rem;
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 600;
   cursor: pointer;
   transition:
     background-color 160ms ease,
@@ -72,14 +72,15 @@ html[data-theme='dark'] .card {
 }
 
 .accept {
-  background: transparent;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  color: var(--ifm-color-emphasis-800);
+  background: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  color: #fff;
 }
 
 .accept:hover {
-  border-color: var(--ifm-color-emphasis-500);
-  background: var(--ifm-color-emphasis-100);
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+  color: #fff;
 }
 
 .button:focus-visible {


### PR DESCRIPTION
## Summary

- **Cookie banner**: Accept now uses the theme color with white text (both modes); button text bumped to 600.
- **Lorenz Attractor**: 3 sliders swapped to laikit `Slider` for visual consistency; Reset button restyled to match the Accent Color Reset (no icon, transparent bg, primary-color hover).
- **Neural Network (light mode)**: neuron ramp goes pure black ↔ pure white; canvas pen strokes switched from blueprint navy to pure black for full contrast.
- **Settings → Accent Color**: color field & Reset borders dropped from 2px to 1px, both radii unified at 10px to match Segmented item / Quick action item.
- **Original Layout**: added missing `isOriginalLayout` gate to `BlogAuthorsListPage` / `BlogAuthorsPostsPage` so author pages also fall back to Docusaurus original when the toggle is on — gate is now uniform across all 7 custom blog page overrides.
- **Changelog**: fix `2026-04-28` entry type `add` → `added`.

## Test plan

- [ ] Cookie banner: open in light + dark, confirm Accept is theme-colored with white text.
- [ ] Home → Lorenz Attractor: 3 sliders look like the laikit slider (white thumb, primary track), Reset button matches Accent Color Reset.
- [ ] Home → Neural Network in light mode: draw a digit and click Check digit — activated neurons go pure black, pen strokes are pure black.
- [ ] Settings → Accent Color: color field and Reset have 1px border, 10px radius, visually aligned.
- [ ] Settings → Experimental → Original Layout ON: visit `/blog/authors` and `/blog/authors/lailai`, confirm Docusaurus default layout renders. Toggle OFF: confirm custom layouts return.
- [ ] Changelog page: 2026-04-28 entry shows the `added` tag style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)