### PR TITLE
Unify NeuralNetwork with Fourier/Lorenz; add laikit Button; fix Bento alignment

### DIFF
--- a/src/components/laikit/Button/index.tsx
+++ b/src/components/laikit/Button/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+export type ButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  'type'
+> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  rounded?: boolean;
+  active?: boolean;
+  fullWidth?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  type?: 'button' | 'submit' | 'reset';
+};
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    children,
+    variant = 'secondary',
+    size = 'md',
+    rounded = false,
+    active = false,
+    fullWidth = false,
+    leftIcon,
+    rightIcon,
+    type = 'button',
+    className,
+    ...rest
+  },
+  ref
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      className={clsx(
+        styles.button,
+        styles[`variant_${variant}`],
+        styles[`size_${size}`],
+        rounded && styles.rounded,
+        active && styles.active,
+        fullWidth && styles.fullWidth,
+        className
+      )}
+      {...rest}
+    >
+      {leftIcon != null && <span className={styles.icon}>{leftIcon}</span>}
+      {children != null && <span className={styles.label}>{children}</span>}
+      {rightIcon != null && <span className={styles.icon}>{rightIcon}</span>}
+    </button>
+  );
+});
+
+export default Button;

--- a/src/components/laikit/Button/styles.module.css
+++ b/src/components/laikit/Button/styles.module.css
@@ -1,0 +1,126 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 10px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  cursor: pointer;
+  appearance: none;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease,
+    color 160ms ease,
+    box-shadow 160ms ease,
+    opacity 160ms ease;
+}
+
+.button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.24);
+}
+
+.button:disabled,
+.button[aria-disabled='true'] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* ── Sizes ─────────────────────────────────────────────────────────── */
+
+.size_sm {
+  height: 32px;
+  padding: 0 0.75rem;
+  font-size: 0.825rem;
+}
+
+.size_md {
+  height: 40px;
+  padding: 0 1rem;
+  font-size: 0.9rem;
+}
+
+.size_lg {
+  height: 48px;
+  padding: 0 1.25rem;
+  font-size: 1rem;
+}
+
+/* ── Shape & layout modifiers ──────────────────────────────────────── */
+
+.rounded {
+  border-radius: 999px;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+/* ── Variants ──────────────────────────────────────────────────────── */
+
+.variant_primary {
+  background: var(--ifm-color-primary);
+  border: 1px solid var(--ifm-color-primary);
+  color: #ffffff;
+}
+
+.variant_primary:not(:disabled):hover {
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+  color: #ffffff;
+}
+
+.variant_secondary {
+  background: transparent;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  color: var(--ifm-color-emphasis-800);
+}
+
+.variant_secondary:not(:disabled):hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.variant_ghost {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.variant_ghost:not(:disabled):hover {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+}
+
+/* ── Active toggle: forces primary look on secondary/ghost ─────────── */
+
+.active.variant_secondary,
+.active.variant_ghost {
+  background: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  color: #ffffff;
+}
+
+.active.variant_secondary:not(:disabled):hover,
+.active.variant_ghost:not(:disabled):hover {
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+  color: #ffffff;
+}
+
+/* ── Icon slots ────────────────────────────────────────────────────── */
+
+.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.label {
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/pages/_components/Bento/styles.module.css
+++ b/src/pages/_components/Bento/styles.module.css
@@ -16,6 +16,7 @@
 }
 
 .cardMain {
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;

--- a/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
+++ b/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
 import { translate } from '@docusaurus/Translate';
 import Slider from '@site/src/components/laikit/Slider';
+import Button from '@site/src/components/laikit/Button';
 import styles from './styles.module.css';
 
 const TWO_PI = 2 * Math.PI;
@@ -419,14 +420,14 @@ export default function LorenzAttractorCanvas() {
           precision={2}
           onChange={setBeta}
         />
-        <button
-          type="button"
+        <Button
+          variant="secondary"
           className={styles.resetButton}
           onClick={handleReset}
           aria-label={RESET_LABEL}
         >
           {RESET_LABEL}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/pages/_components/LorenzAttractor/styles.module.css
+++ b/src/pages/_components/LorenzAttractor/styles.module.css
@@ -72,27 +72,6 @@ html[data-theme='dark'] .canvas {
 
 .resetButton {
   flex-shrink: 0;
-  height: 40px;
-  padding: 0 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 10px;
-  color: var(--ifm-color-emphasis-700);
-  cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition:
-    border-color 0.2s ease,
-    color 0.2s ease;
-}
-
-.resetButton:hover {
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
 }
 
 @media (max-width: 500px) {
@@ -101,6 +80,6 @@ html[data-theme='dark'] .canvas {
   }
   .resetButton {
     grid-column: 1 / -1;
-    justify-content: center;
+    width: 100%;
   }
 }

--- a/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
+++ b/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
@@ -2,7 +2,23 @@
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import clsx from 'clsx';
+import { translate } from '@docusaurus/Translate';
+import Button from '@site/src/components/laikit/Button';
 import styles from './styles.module.css';
+
+const CLEAR_LABEL = translate({
+  id: 'home.neuralnetwork.clear',
+  message: 'Clear',
+});
+const CHECK_LABEL = translate({
+  id: 'home.neuralnetwork.check',
+  message: 'Check digit',
+});
+const PREPROCESS_LABEL = translate({
+  id: 'home.neuralnetwork.preprocess',
+  message: 'Pre-process',
+});
 
 type Point = { x: number; y: number };
 type NormData = { scale: number; centerX: number; centerY: number };
@@ -21,11 +37,15 @@ const visibleNeurons: (number | null)[][] = [
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
 ];
 
+// Square 500×500 canvas, matching Fourier Transform's canvas.
+const CANVAS_SIZE = 500;
+const CANVAS_CENTER = CANVAS_SIZE / 2;
+
 function getNeuronPosition(layerIndex: number, visibleNeuronIndex: number) {
   const count = visibleNeurons[layerIndex].length;
   return {
-    x: 230 + 115 * layerIndex,
-    y: 240 + 28 * (visibleNeuronIndex - (count - 1) / 2),
+    x: 175 + 90 * layerIndex,
+    y: CANVAS_CENTER + 25 * (visibleNeuronIndex - (count - 1) / 2),
   };
 }
 
@@ -113,19 +133,24 @@ export default function NeuralNetworkInteractive({
     }
   }, [isNormalized, normalizePointsAnimated]);
 
+  const inputValues = useMemo(() => getInputNeuronValues(points), [points]);
+  const isEmpty = !inputValues.some((v) => v > 0.1);
+
   if (!dataLoaded) {
-    return <div className={styles.container} style={{ minHeight: 480 }} />;
+    return <div className={styles.container} style={{ minHeight: CANVAS_SIZE }} />;
   }
 
   const compact = animating || instant;
+  const editing = !animating || instant;
 
   return (
     <div className={styles.container}>
+      <div className={styles.frame}>
       <svg
         className={styles.svg}
-        width={640}
-        height={480}
-        viewBox="0 0 640 480"
+        width={CANVAS_SIZE}
+        height={CANVAS_SIZE}
+        viewBox={`0 0 ${CANVAS_SIZE} ${CANVAS_SIZE}`}
         style={{ touchAction: 'none' }}
       >
         <NeuronConnections
@@ -133,7 +158,7 @@ export default function NeuralNetworkInteractive({
           animating={animating}
           instant={instant}
         />
-        <VerticalEllipsis cx={230} cy={240} />
+        <VerticalEllipsis cx={175} cy={CANVAS_CENTER} />
         <Neurons
           neurons={neurons}
           selectedNeuron={selectedNeuron}
@@ -156,10 +181,10 @@ export default function NeuralNetworkInteractive({
             );
             return (
               <WeightGrid
-                x={pos.x + 20}
-                y={-40 + (pos.y - 240) * 0.85 + 240}
-                width={85}
-                height={85}
+                x={pos.x + 14}
+                y={-30 + (pos.y - CANVAS_CENTER) * 0.85 + CANVAS_CENTER}
+                width={65}
+                height={65}
                 weights={weights![0][selectedNeuron.neuronId]}
                 inputNeurons={neurons[0]}
               />
@@ -170,8 +195,8 @@ export default function NeuralNetworkInteractive({
           <rect
             x="0"
             y="0"
-            width="640"
-            height="480"
+            width={CANVAS_SIZE}
+            height={CANVAS_SIZE}
             fill="var(--ifm-background-color)"
             style={{
               opacity: animating ? 0 : 1,
@@ -182,31 +207,68 @@ export default function NeuralNetworkInteractive({
         )}
 
         <ImageGrid
-          instant={instant}
-          editing={!animating || instant}
+          editing={editing}
           startEditing={() => {
             setAnimating(false);
             setPoints([]);
             setIsNormalized(false);
           }}
-          x={compact ? 10 : 125}
-          y={10}
-          width={compact ? 190 : 390}
-          height={compact ? 190 : 390}
+          x={compact ? 10 : 70}
+          y={compact ? 10 : 30}
+          width={compact ? 130 : 360}
+          height={compact ? 130 : 360}
           points={points}
+          inputValues={inputValues}
           setPoints={(newPoints) => {
             setPoints(newPoints);
             setIsNormalized(false);
           }}
           normalizing={normalizing}
-          isNormalized={isNormalized}
-          normalizePointsAnimated={normalizePointsAnimated}
-          beginAnimation={animate}
           highlightedTile={
             selectedNeuron?.layerIndex === 0 ? selectedNeuron.neuronId : null
           }
         />
       </svg>
+
+        <div
+          className={clsx(styles.controls, !editing && styles.controlsHidden)}
+          aria-hidden={!editing}
+        >
+          <Button
+            variant="secondary"
+            fullWidth
+            disabled={isEmpty}
+            className={styles.buttonSlot}
+            onClick={() => {
+              setPoints([]);
+              setIsNormalized(false);
+            }}
+          >
+            {CLEAR_LABEL}
+          </Button>
+          {instant ? (
+            <Button
+              variant="primary"
+              fullWidth
+              disabled={isEmpty || isNormalized}
+              className={styles.buttonSlot}
+              onClick={() => normalizePointsAnimated(1)}
+            >
+              {PREPROCESS_LABEL}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              fullWidth
+              disabled={isEmpty}
+              className={styles.buttonSlot}
+              onClick={animate}
+            >
+              {CHECK_LABEL}
+            </Button>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
@@ -329,7 +391,7 @@ function Neurons({
               key={`${layerIndex}-${neuronId}`}
               cx={pos.x}
               cy={pos.y}
-              r={10}
+              r={8}
               stroke={
                 isSelected
                   ? 'var(--nn-neuron-border-selected)'
@@ -368,19 +430,22 @@ function WinningOutputNeuronBox({
   const outputLayer = neurons[3];
   const winningNeuron = outputLayer.indexOf(Math.max(...outputLayer));
   const pos = getNeuronPosition(3, winningNeuron);
+  const w = 44;
+  const h = 24;
+  const perimeter = 2 * (w + h);
   return (
     <rect
-      x={pos.x - 18}
-      y={pos.y - 16}
-      width={56}
-      height={32}
+      x={pos.x - 13}
+      y={pos.y - 12}
+      width={w}
+      height={h}
       stroke="var(--nn-stroke-accent)"
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
       fill="none"
-      strokeDasharray="176 176"
-      strokeDashoffset={(animating || instant ? 0 : 1) * 176}
+      strokeDasharray={`${perimeter} ${perimeter}`}
+      strokeDashoffset={(animating || instant ? 0 : 1) * perimeter}
       style={{
         transition: animating
           ? `stroke-dashoffset 800ms ease-in-out ${instant ? '0ms' : '4500ms'}`
@@ -399,10 +464,10 @@ function OutputDigitLabels() {
         return (
           <text
             key={neuronId}
-            x={pos.x + 25}
-            y={pos.y + 2}
+            x={pos.x + 22}
+            y={pos.y + 1}
             style={{ fill: 'var(--nn-text-primary)' }}
-            fontSize={20}
+            fontSize={16}
             dominantBaseline="middle"
             textAnchor="middle"
           >
@@ -420,14 +485,11 @@ interface ImageGridProps {
   width: number;
   height: number;
   points: Point[];
+  inputValues: number[];
   setPoints: (points: Point[]) => void;
   normalizing: boolean;
-  isNormalized: boolean;
-  normalizePointsAnimated: (duration?: number) => Promise<void>;
-  instant: boolean;
   editing: boolean;
   startEditing: () => void;
-  beginAnimation: () => void;
   highlightedTile: number | null;
 }
 
@@ -437,14 +499,11 @@ function ImageGrid({
   width,
   height,
   points,
+  inputValues,
   setPoints,
   normalizing,
-  isNormalized,
-  normalizePointsAnimated,
-  instant,
   editing,
   startEditing,
-  beginAnimation,
   highlightedTile,
 }: ImageGridProps) {
   const [dragging, setDragging] = useState(false);
@@ -527,9 +586,6 @@ function ImageGrid({
     };
   }, [onMouseUp]);
 
-  const values = useMemo(() => getInputNeuronValues(points), [points]);
-  const isEmpty = !values.some((v) => v > 0.1);
-
   return (
     <g
       style={{
@@ -540,7 +596,7 @@ function ImageGrid({
       <rect x={0} y={0} width={400} height={400} fill="var(--nn-bg-primary)" />
 
       <g>
-        {values.map((value, n) => (
+        {inputValues.map((value, n) => (
           <rect
             key={n}
             x={(n % 28) * (400 / 28)}
@@ -586,8 +642,8 @@ function ImageGrid({
         y={0}
         width={400}
         height={400}
-        stroke="var(--nn-stroke-primary)"
-        strokeWidth="2"
+        stroke="var(--nn-stroke-subtle)"
+        strokeWidth="1"
         rx="2"
         fill="var(--nn-transparent)"
         style={{ cursor: editing ? 'crosshair' : 'pointer' }}
@@ -597,101 +653,6 @@ function ImageGrid({
         onMouseMove={onMouseMove}
         onTouchMove={onMouseMove}
       />
-
-      <g
-        transform="translate(0 410)"
-        style={{
-          opacity: editing ? 1 : 0,
-          pointerEvents: editing ? undefined : 'none',
-          transition: 'opacity 500ms ease-in-out',
-        }}
-      >
-        <SvgButton
-          x={0}
-          y={0}
-          width={150}
-          height={60}
-          label="Clear"
-          primary={false}
-          disabled={isEmpty}
-          onClick={() => setPoints([])}
-        />
-        {!instant ? (
-          <SvgButton
-            x={200}
-            y={0}
-            width={200}
-            height={60}
-            label="Check digit"
-            primary
-            disabled={isEmpty}
-            onClick={beginAnimation}
-          />
-        ) : (
-          <SvgButton
-            x={200}
-            y={0}
-            width={200}
-            height={60}
-            label="Pre-process"
-            primary
-            disabled={isEmpty || isNormalized}
-            onClick={() => normalizePointsAnimated(1)}
-          />
-        )}
-      </g>
-    </g>
-  );
-}
-
-function SvgButton({
-  x,
-  y,
-  width,
-  height,
-  label,
-  primary,
-  disabled,
-  onClick,
-}: {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-  label: string;
-  primary: boolean;
-  disabled: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <g>
-      <rect
-        className={primary ? styles.checkButton : styles.clearButton}
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        tabIndex={0}
-        rx={12}
-        onClick={disabled ? undefined : onClick}
-        style={{
-          cursor: disabled ? 'default' : 'pointer',
-          opacity: disabled ? 0.5 : 1,
-          transition: 'all 0.2s ease',
-        }}
-      />
-      <text
-        x={x + width / 2}
-        y={y + height / 2 + 2}
-        dominantBaseline="middle"
-        textAnchor="middle"
-        fill={primary ? 'white' : 'var(--ifm-font-color-base)'}
-        fontFamily="sans-serif"
-        fontSize={24}
-        style={{ pointerEvents: 'none', opacity: disabled ? 0.5 : 1 }}
-      >
-        {label}
-      </text>
     </g>
   );
 }
@@ -705,9 +666,9 @@ const VerticalEllipsis = React.memo(function VerticalEllipsis({
 }) {
   return (
     <g>
-      <circle cx={cx} cy={cy - 12} r={3} fill="var(--nn-grid-white)" />
-      <circle cx={cx} cy={cy} r={3} fill="var(--nn-grid-white)" />
-      <circle cx={cx} cy={cy + 12} r={3} fill="var(--nn-grid-white)" />
+      <circle cx={cx} cy={cy - 10} r={2.5} fill="var(--nn-grid-white)" />
+      <circle cx={cx} cy={cy} r={2.5} fill="var(--nn-grid-white)" />
+      <circle cx={cx} cy={cy + 10} r={2.5} fill="var(--nn-grid-white)" />
     </g>
   );
 });

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -6,9 +6,9 @@
 
   --nn-text-primary: #ffffff;
   --nn-text-secondary: #000000;
-  --nn-text-accent: #ffff00;
+  --nn-text-accent: var(--ifm-color-primary);
 
-  --nn-neuron-border-selected: #ffff00;
+  --nn-neuron-border-selected: var(--ifm-color-primary);
   --nn-neuron-border-default: #ffffff;
   --nn-neuron-fill-default: #000000;
 
@@ -16,43 +16,47 @@
   --nn-neuron-gray-base: 0;
   --nn-neuron-gray-multiplier: 255;
 
-  --nn-connection-negative-rgb: 252, 98, 85;
-  --nn-connection-positive-rgb: 88, 196, 221;
-  --nn-connection-animation: rgba(255, 255, 0, 0.5);
+  /* Aligned with Lorenz Attractor's blue/orange trail palette. */
+  --nn-connection-negative-rgb: 249, 115, 22;
+  --nn-connection-positive-rgb: 29, 155, 240;
+  --nn-connection-animation: rgba(var(--ifm-color-primary-rgb), 0.55);
   --nn-connection-default: #666666;
 
-  --nn-button-clear: var(--ifm-card-background-color);
-  --nn-button-clear-border: var(--ifm-color-emphasis-300);
-  --nn-button-primary: var(--ifm-color-primary);
-  --nn-button-primary-border: var(--ifm-color-primary);
-
-  --nn-stroke-primary: var(--ifm-color-primary);
-  --nn-stroke-accent: #ffff00;
+  --nn-stroke-accent: var(--ifm-color-primary);
+  --nn-stroke-subtle: var(--ifm-color-emphasis-300);
 
   --nn-grid-white: #ffffff;
   --nn-grid-white-rgb: 255, 255, 255;
-  --nn-grid-stroke: #ffff00;
+  --nn-grid-stroke: var(--ifm-color-primary);
   --nn-grid-fill: #000000;
 
   width: 100%;
-  max-width: 640px;
+  max-width: 500px;
   margin: 0 auto;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+}
+
+.frame {
+  position: relative;
+  width: 100%;
+  max-width: 500px;
+  aspect-ratio: 1 / 1;
+  background: var(--nn-bg-primary);
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 /* Light theme — "Blueprint" palette. */
 [data-theme='light'] .container {
   --nn-bg-primary: #ffffff;
   --nn-bg-overlay: rgba(255, 255, 255, 0.88);
-  --nn-transparent: transparent;
 
   --nn-text-primary: #1e2040;
   --nn-text-secondary: #ffffff;
-  --nn-text-accent: var(--ifm-color-primary);
 
-  --nn-neuron-border-selected: var(--ifm-color-primary);
   --nn-neuron-border-default: #94a3b8;
   --nn-neuron-fill-default: #ffffff;
 
@@ -60,30 +64,18 @@
   --nn-neuron-gray-base: 255;
   --nn-neuron-gray-multiplier: -255;
 
-  --nn-connection-negative-rgb: 239, 68, 68;
-  --nn-connection-positive-rgb: 59, 130, 246;
-  --nn-connection-animation: rgba(99, 102, 241, 0.75);
+  --nn-connection-animation: rgba(var(--ifm-color-primary-rgb), 0.7);
   --nn-connection-default: #c7d2fe;
-
-  --nn-button-clear: var(--ifm-card-background-color);
-  --nn-button-clear-border: var(--ifm-color-emphasis-200);
-  --nn-button-primary: var(--ifm-color-primary);
-  --nn-button-primary-border: var(--ifm-color-primary);
-
-  --nn-stroke-primary: var(--ifm-color-primary);
-  --nn-stroke-accent: var(--ifm-color-primary);
 
   --nn-grid-white: #000000;
   --nn-grid-white-rgb: 0, 0, 0;
-  --nn-grid-stroke: var(--ifm-color-primary);
   --nn-grid-fill: #ffffff;
 }
 
 .svg {
   display: block;
   width: 100%;
-  height: auto;
-  max-width: 640px;
+  height: 100%;
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
@@ -91,46 +83,38 @@
   -ms-user-select: none;
 }
 
-.clearButton {
-  fill: var(--nn-button-clear);
-  stroke: var(--nn-button-clear-border);
-  stroke-width: 2;
-  cursor: pointer;
-  transition: all 0.2s ease;
+.controls {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 8%;
+  display: flex;
+  gap: 0.85rem;
+  justify-content: center;
+  align-items: stretch;
+  padding: 0 1.5rem;
+  opacity: 1;
+  pointer-events: auto;
+  transition:
+    opacity 300ms ease-in-out,
+    visibility 0s linear 0s;
 }
 
-.clearButton:hover {
-  stroke: var(--ifm-color-primary);
-  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.1));
+.controlsHidden {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+  transition:
+    opacity 300ms ease-in-out,
+    visibility 0s linear 300ms;
 }
 
-.checkButton {
-  fill: var(--nn-button-primary);
-  stroke: var(--nn-button-primary-border);
-  stroke-width: 2;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.checkButton:hover {
-  fill: var(--ifm-color-primary-dark);
-  stroke: var(--ifm-color-primary-dark);
-  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.1));
+.buttonSlot {
+  max-width: 200px;
 }
 
 @media (max-width: 768px) {
   .container {
     margin: 0;
   }
-}
-
-html[data-theme='dark'] .clearButton:hover {
-  stroke: var(--ifm-color-primary-light) !important;
-  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.3));
-}
-
-html[data-theme='dark'] .checkButton:hover {
-  fill: var(--ifm-color-primary-light) !important;
-  stroke: var(--ifm-color-primary-light) !important;
-  filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.3));
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { Icon } from '@iconify/react';
 import { translate } from '@docusaurus/Translate';
 import clsx from 'clsx';
+import Button from '@site/src/components/laikit/Button';
 import styles from './styles.module.css';
 
 import Blog from './_components/Blog';
@@ -74,14 +75,18 @@ export default function Home(): ReactNode {
           )}
         >
           <Bento />
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
+            rounded
             className={styles.scrollGuide}
+            rightIcon={
+              <Icon icon="lucide:chevrons-down" width={16} height={16} />
+            }
             onClick={handleRevealHome}
           >
-            <span>{SCROLL_GUIDE_LABEL}</span>
-            <Icon icon="lucide:chevrons-down" width={16} height={16} />
-          </button>
+            {SCROLL_GUIDE_LABEL}
+          </Button>
         </section>
       )}
     </Layout>

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -8,6 +8,7 @@ import DataCard from '@site/src/components/laikit/DataCard';
 import Card from '@site/src/components/laikit/Card';
 import IconBlock from '@site/src/components/laikit/IconBlock';
 import IconText from '@site/src/components/laikit/IconText';
+import Button from '@site/src/components/laikit/Button';
 
 import { usePluralForm } from '@docusaurus/theme-common';
 import {
@@ -93,29 +94,29 @@ function CategoryNav({
   return (
     <nav className={styles.categoryNav}>
       <div className={styles.categoryNavContent}>
-        <button
-          className={clsx(
-            styles.categoryButton,
-            activeCategory === 'all' && styles.categoryButtonActive
-          )}
+        <Button
+          variant="secondary"
+          rounded
+          active={activeCategory === 'all'}
+          className={styles.categoryButton}
           onClick={() => onCategoryChange('all')}
         >
           {translate({
             id: 'pages.resources.category.all',
             message: 'All',
           })}
-        </button>
+        </Button>
         {categories.map((category) => (
-          <button
+          <Button
             key={category.title}
-            className={clsx(
-              styles.categoryButton,
-              activeCategory === category.title && styles.categoryButtonActive
-            )}
+            variant="secondary"
+            rounded
+            active={activeCategory === category.title}
+            className={styles.categoryButton}
             onClick={() => onCategoryChange(category.title)}
           >
             {category.title}
-          </button>
+          </Button>
         ))}
       </div>
     </nav>
@@ -255,15 +256,16 @@ function ResourcesMain() {
               { query: searchQuery }
             )}
           </p>
-          <button
-            className={styles.clearSearchButton}
+          <Button
+            variant="primary"
+            rounded
             onClick={() => setSearchQuery('')}
           >
             {translate({
               id: 'pages.resources.noresults.clear',
               message: 'Clear Search',
             })}
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/src/pages/resources/styles.module.css
+++ b/src/pages/resources/styles.module.css
@@ -59,35 +59,8 @@
   justify-content: center;
 }
 
-.categoryButton {
-  background: var(--ifm-background-color);
-  border: 2px solid var(--ifm-color-emphasis-300);
-  color: var(--ifm-font-color-base);
-  border-radius: 50px;
-  padding: 0.75rem 1rem;
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-  white-space: nowrap;
-}
-
 .categoryButton:hover {
-  border-color: var(--ifm-color-primary);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
-
-.categoryButtonActive {
-  background: var(--ifm-color-primary);
-  border-color: var(--ifm-color-primary);
-  color: white;
-  box-shadow: 0 4px 12px rgba(var(--ifm-color-primary-rgb), 0.3);
-}
-
-.categoryButtonActive:hover {
-  background: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: white;
 }
 
 /* Category sections & resource grid */
@@ -191,21 +164,6 @@
 .noResults p {
   margin-bottom: 1.5rem;
   font-size: 1.1rem;
-}
-
-.clearSearchButton {
-  background-color: var(--ifm-color-primary);
-  color: white;
-  border: none;
-  padding: 0.6rem 1.2rem;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 1rem;
-  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
-}
-
-.clearSearchButton:hover {
-  background-color: var(--ifm-color-primary-dark);
 }
 
 /* Responsive */

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -11,6 +11,7 @@ import Segmented, {
 import Switch from '@site/src/components/laikit/Switch';
 import Slider from '@site/src/components/laikit/Slider';
 import DataCard from '@site/src/components/laikit/DataCard';
+import Button from '@site/src/components/laikit/Button';
 import {
   SETTINGS_EXPERIMENTAL_DEFAULT,
   SETTINGS_PRESET_COLOR_LIST,
@@ -130,8 +131,9 @@ function AccentColor() {
               size={8}
             />
           </label>
-          <button
-            type="button"
+          <Button
+            variant="secondary"
+            size="sm"
             className={styles.resetButton}
             onClick={resetColors}
           >
@@ -139,12 +141,15 @@ function AccentColor() {
               id: 'pages.settings.item.color.reset',
               message: 'Reset',
             })}
-          </button>
+          </Button>
         </div>
         <div className={styles.presetColors}>
           {SETTINGS_PRESET_COLOR_LIST.map((color) => (
-            <button
+            <Button
               key={color}
+              variant="ghost"
+              rounded
+              aria-label={color}
               className={styles.presetColorButton}
               style={{
                 background: `linear-gradient(to right, ${color} 0 50%, ${Color(color).mix(Color('#fff'), 0.3).hex()} 50% 100%)`,
@@ -411,14 +416,17 @@ function QuickActions() {
       <ul className={styles.actionList}>
         {quickActionOptions.map((option) => (
           <li key={option.key}>
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              fullWidth
               className={styles.actionItem}
+              leftIcon={
+                <Icon icon={option.icon} className={styles.actionItemIcon} />
+              }
               onClick={option.onClick}
             >
-              <Icon icon={option.icon} className={styles.actionItemIcon} />
-              <span>{option.label}</span>
-            </button>
+              {option.label}
+            </Button>
           </li>
         ))}
       </ul>

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -145,39 +145,19 @@
 .presetColorButton {
   width: 28px;
   height: 28px;
+  min-height: 0;
+  padding: 0;
   border: 0;
-  border-radius: 50%;
-  cursor: pointer;
   transition: transform 0.2s;
 }
 
 .presetColorButton:hover {
+  background: inherit !important;
   transform: scale(1.1);
 }
 
 .resetButton {
   flex-shrink: 0;
-  height: 40px;
-  padding: 0 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  border-radius: 10px;
-  color: var(--ifm-color-emphasis-700);
-  cursor: pointer;
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  transition:
-    border-color 0.2s ease,
-    color 0.2s ease;
-}
-
-.resetButton:hover {
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
 }
 
 /* Typography sliders */
@@ -246,53 +226,10 @@
 }
 
 .actionItem {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  width: 100%;
-  padding: 0.75rem 0.95rem;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: transparent;
-  border-radius: 10px;
-  cursor: pointer;
-  color: var(--ifm-font-color-base);
-  font-weight: 600;
-  font-size: 0.92rem;
-  letter-spacing: 0.01em;
+  justify-content: flex-start;
   text-align: left;
-  outline: none;
-  transition:
-    border-color 0.2s ease,
-    color 0.2s ease,
-    box-shadow 0.2s ease;
-}
-
-.actionItem:hover {
-  border-color: var(--ifm-color-primary);
-  color: var(--ifm-color-primary);
-}
-
-html[data-theme='dark'] .actionItem:hover {
-  color: var(--ifm-color-primary-light);
-  border-color: var(--ifm-color-primary-light);
-}
-
-.actionItem:focus-visible {
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.2);
 }
 
 .actionItemIcon {
-  flex-shrink: 0;
   font-size: 1.05rem;
-  color: var(--ifm-color-emphasis-700);
-  transition: color 0.2s ease;
-}
-
-.actionItem:hover .actionItemIcon {
-  color: var(--ifm-color-primary);
-}
-
-html[data-theme='dark'] .actionItem:hover .actionItemIcon {
-  color: var(--ifm-color-primary-light);
 }

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -20,20 +20,8 @@
   left: 50%;
   bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
   transform: translateX(-50%);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-300);
   background: var(--ifm-background-color);
-  color: var(--ifm-color-emphasis-700);
   opacity: 0.45;
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  line-height: 1;
-  cursor: pointer;
   transition: opacity 0.2s ease;
 }
 
@@ -44,8 +32,6 @@
 @media (max-width: 768px) {
   .scrollGuide {
     bottom: calc(0.75rem + env(safe-area-inset-bottom, 0px));
-    padding: 0.4rem 0.75rem;
-    font-size: 0.72rem;
   }
 }
 

--- a/src/theme/Root/CookieConsent/index.tsx
+++ b/src/theme/Root/CookieConsent/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import Card from '@site/src/components/laikit/Card';
+import Button from '@site/src/components/laikit/Button';
 import styles from './styles.module.css';
 
 const STORAGE_KEY = 'cookie-consent';
@@ -42,7 +43,7 @@ export default function CookieConsent() {
       aria-live="polite"
       aria-label="Cookie consent"
     >
-      <Card padding="1rem 1.125rem" className={styles.card}>
+      <Card padding="1.25rem" className={styles.card}>
         <div className={styles.content}>
           <div className={styles.title}>
             <Translate id="cookieConsent.title">Cookie Settings</Translate>
@@ -66,20 +67,22 @@ export default function CookieConsent() {
             </Translate>
           </p>
           <div className={styles.actions}>
-            <button
-              type="button"
-              className={`${styles.button} ${styles.reject}`}
+            <Button
+              variant="secondary"
+              size="sm"
+              rounded
               onClick={() => handleChoice('rejected')}
             >
               <Translate id="cookieConsent.reject">Reject</Translate>
-            </button>
-            <button
-              type="button"
-              className={`${styles.button} ${styles.accept}`}
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              rounded
               onClick={() => handleChoice('accepted')}
             >
               <Translate id="cookieConsent.accept">Accept</Translate>
-            </button>
+            </Button>
           </div>
         </div>
       </Card>

--- a/src/theme/Root/CookieConsent/styles.module.css
+++ b/src/theme/Root/CookieConsent/styles.module.css
@@ -46,48 +46,6 @@ html[data-theme='dark'] .card {
   margin-top: 0.25rem;
 }
 
-.button {
-  appearance: none;
-  border-radius: 999px;
-  padding: 0.4rem 1rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background-color 160ms ease,
-    border-color 160ms ease,
-    color 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.reject {
-  background: transparent;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  color: var(--ifm-color-emphasis-800);
-}
-
-.reject:hover {
-  border-color: var(--ifm-color-emphasis-500);
-  background: var(--ifm-color-emphasis-100);
-}
-
-.accept {
-  background: var(--ifm-color-primary);
-  border: 1px solid var(--ifm-color-primary);
-  color: #fff;
-}
-
-.accept:hover {
-  background: var(--ifm-color-primary-dark);
-  border-color: var(--ifm-color-primary-dark);
-  color: #fff;
-}
-
-.button:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.24);
-}
-
 @media (max-width: 480px) {
   .banner {
     left: 0.75rem;


### PR DESCRIPTION
## Summary

Three-part visual/architectural cleanup of the home page and the laikit kit.

### 1. NeuralNetwork → unified with Fourier / Lorenz
- Square 500×500 canvas (matches `FourierTransform`'s `BASE_SIZE`)
- Buttons (Clear / Check digit) moved inside the frame as HTML, not SVG
- Recomputed all geometry: layer x's, neuron y's, ellipsis, weight grid, winning-output box
- Replaced yellow `#ffff00` accents with `var(--ifm-color-primary)`
- Connection palette aligned with Lorenz Attractor's blue/orange trails

### 2. New `laikit/Button` component + 13 migrations
- API: `variant: primary | secondary | ghost`, `size: sm | md | lg`, plus `rounded`, `active`, `fullWidth`, `leftIcon`, `rightIcon`
- ForwardRef + full native `<button>` prop passthrough
- Migrated every page-level `<button>` to it (NeuralNetwork ×3, LorenzAttractor, CookieConsent ×2, Scroll Down, resources ×3, settings ×3)
- Removed ~180 lines of duplicated button CSS across 6 stylesheets
- Only remaining native `<button>` is inside `laikit/Segmented` (intentional — segmented control)

### 3. Bento home cover alignment fix
The lailai card visually ended 7px above the Project/Blog row bottom. Root cause: `<Link className={cardMainLink}>` is the grid item and stretched to 216px, but the inner `<Card>` had no `height: 100%` and only sized to its content (209px). Fix: add `height: 100%` to `.cardMain`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] dev server compiles successfully
- [x] NN editing/animating modes verified in dark + light
- [x] Lorenz Reset, CookieConsent (Reject/Accept), Scroll Down, resources filters, settings (Reset / color swatches / Quick Actions) all migrated and verified visually
- [x] Bento alignment confirmed: lailai card height = Contest+gap+Project = 216px

🤖 Generated with [Claude Code](https://claude.com/claude-code)