### PR TITLE
Unify canvas frames: Fourier/Lorenz use Card; NN has no frame

### DIFF
--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { useColorMode } from '@docusaurus/theme-common';
+import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
 const TWO_PI = 2 * Math.PI;
@@ -391,17 +392,19 @@ export default function FourierTransformCanvas() {
 
   return (
     <div ref={containerRef} className={styles.container}>
-      <canvas
-        ref={canvasRef}
-        width={canvasSize * dpr}
-        height={canvasSize * dpr}
-        style={{ width: canvasSize, height: canvasSize }}
-        className={styles.canvas}
-        onPointerDown={handleStart}
-        onPointerMove={handleMove}
-        onPointerUp={handleEnd}
-        onPointerCancel={handleEnd}
-      />
+      <Card padding="0" className={styles.cardSurface}>
+        <canvas
+          ref={canvasRef}
+          width={canvasSize * dpr}
+          height={canvasSize * dpr}
+          style={{ width: canvasSize, height: canvasSize }}
+          className={styles.canvas}
+          onPointerDown={handleStart}
+          onPointerMove={handleMove}
+          onPointerUp={handleEnd}
+          onPointerCancel={handleEnd}
+        />
+      </Card>
     </div>
   );
 }

--- a/src/pages/_components/FourierTransform/styles.module.css
+++ b/src/pages/_components/FourierTransform/styles.module.css
@@ -7,11 +7,13 @@
   align-items: center;
 }
 
+.cardSurface {
+  overflow: hidden;
+  line-height: 0;
+}
+
 .canvas {
   display: block;
-  border-radius: 12px;
   cursor: crosshair;
   touch-action: none;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--ifm-color-emphasis-300);
 }

--- a/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
+++ b/src/pages/_components/LorenzAttractor/LorenzAttractorCanvas.tsx
@@ -3,6 +3,7 @@ import { useColorMode } from '@docusaurus/theme-common';
 import { translate } from '@docusaurus/Translate';
 import Slider from '@site/src/components/laikit/Slider';
 import Button from '@site/src/components/laikit/Button';
+import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
 const TWO_PI = 2 * Math.PI;
@@ -381,17 +382,19 @@ export default function LorenzAttractorCanvas() {
 
   return (
     <div ref={containerRef} className={styles.container}>
-      <canvas
-        ref={canvasRef}
-        width={canvasSize * dpr}
-        height={canvasSize * dpr}
-        style={{ width: canvasSize, height: canvasSize }}
-        className={styles.canvas}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-      />
+      <Card padding="0" className={styles.cardSurface}>
+        <canvas
+          ref={canvasRef}
+          width={canvasSize * dpr}
+          height={canvasSize * dpr}
+          style={{ width: canvasSize, height: canvasSize }}
+          className={styles.canvas}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        />
+      </Card>
       <div className={styles.controls}>
         <ParamSlider
           label="σ"

--- a/src/pages/_components/LorenzAttractor/styles.module.css
+++ b/src/pages/_components/LorenzAttractor/styles.module.css
@@ -8,19 +8,22 @@
   gap: 1.25rem;
 }
 
-.canvas {
-  display: block;
+.cardSurface {
   width: 100%;
-  border-radius: 12px;
-  cursor: grab;
-  touch-action: none;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-  border: 1px solid var(--ifm-color-emphasis-300);
+  overflow: hidden;
+  line-height: 0;
   background: #ffffff;
 }
 
-html[data-theme='dark'] .canvas {
+html[data-theme='dark'] .cardSurface {
   background: #000000;
+}
+
+.canvas {
+  display: block;
+  width: 100%;
+  cursor: grab;
+  touch-action: none;
 }
 
 .canvas:active {

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -43,10 +43,6 @@
   width: 100%;
   max-width: 500px;
   aspect-ratio: 1 / 1;
-  background: var(--nn-bg-primary);
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-300);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 /* Light theme — "Blueprint" palette. */


### PR DESCRIPTION
## Summary

Unify the outer chrome of the three home-page interactive components against the rest of the site.

- **Fourier Transform** & **Lorenz Attractor** — wrap the canvas in `<Card padding=\"0\">` so they inherit laikit/Card's exact chrome (16px radius, emphasis-200 border, `0 6px 16px rgba(0,0,0,0.06)` shadow, card background). Removes the bespoke `12px / emphasis-300 / 0 4px 20px` frame they each hand-rolled.
- **Neural Network** — strip the `.frame` chrome (background, border, radius, shadow) entirely. The component now renders just the visualization surface + buttons; only `position: relative` + `aspect-ratio: 1/1` remain so the absolutely-positioned controls keep their layout.

After this change, every framed card-like surface on the site (Bento, about, friends, resources, settings, blog, Fourier, Lorenz) shares the same chrome via `laikit/Card`. NN is intentionally frameless.

## Test plan
- [x] `dev server` compiles successfully
- [x] Fourier visual: Card-style 16px rounded frame with the canvas clipped via `overflow: hidden` on `.cardSurface`
- [x] Lorenz visual: same Card frame; black/white canvas background applied on `.cardSurface` so the Card's default bg never bleeds through
- [x] NN visual: no border, no shadow, no background — just the inner image grid + buttons, dark/light themes both working

🤖 Generated with [Claude Code](https://claude.com/claude-code)