### PR TITLE
Tighten visual unity: add LinkCard, prune redundant Card overrides

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -695,6 +695,15 @@
   "home.neuralnetwork.description": {
     "message": "在下方绘制数字 0–9，神经网络会识别您的手写数字"
   },
+  "home.neuralnetwork.clear": {
+    "message": "清除"
+  },
+  "home.neuralnetwork.check": {
+    "message": "识别数字"
+  },
+  "home.neuralnetwork.preprocess": {
+    "message": "预处理"
+  },
   "home.fouriertransform.title": {
     "message": "傅立叶变换"
   },

--- a/src/components/BrowserWindow/index.tsx
+++ b/src/components/BrowserWindow/index.tsx
@@ -1,5 +1,6 @@
 import React, { type CSSProperties, type ReactNode } from 'react';
 import clsx from 'clsx';
+import Card from '@site/src/components/laikit/Card';
 
 import styles from './styles.module.css';
 
@@ -19,7 +20,11 @@ export default function BrowserWindow({
   bodyStyle,
 }: Props) {
   return (
-    <div className={styles.browserWindow} style={{ ...style, minHeight }}>
+    <Card
+      padding={0}
+      className={styles.browserWindow}
+      style={{ ...style, minHeight }}
+    >
       <div className={styles.browserWindowHeader}>
         <div className={styles.buttons}>
           <span className={styles.dot} style={{ background: '#ff5f57' }} />
@@ -35,7 +40,7 @@ export default function BrowserWindow({
       <div className={styles.browserWindowBody} style={bodyStyle}>
         {children}
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/src/components/BrowserWindow/styles.module.css
+++ b/src/components/BrowserWindow/styles.module.css
@@ -1,14 +1,6 @@
 .browserWindow {
-  background-color: var(--ifm-background-color);
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  border-radius: 12px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.06);
   margin-bottom: var(--ifm-leading);
   overflow: hidden;
-}
-
-[data-theme='dark'] .browserWindow {
-  border-color: rgba(255, 255, 255, 0.08);
 }
 
 .browserWindowHeader {

--- a/src/components/laikit/IconText/index.tsx
+++ b/src/components/laikit/IconText/index.tsx
@@ -5,14 +5,14 @@ interface IconTextProps {
   icon: string;
   children: React.ReactNode;
   size?: string;
-  colorMode?: 'theme' | 'monochrome';
+  monochrome?: boolean;
 }
 
 export default function IconText({
   icon,
   children,
   size = '1.25em',
-  colorMode = 'theme',
+  monochrome = false,
 }: IconTextProps) {
   return (
     <span className={styles.iconText}>
@@ -20,7 +20,7 @@ export default function IconText({
         icon={icon}
         width={size}
         height={size}
-        className={colorMode === 'theme' ? styles.iconTheme : undefined}
+        className={monochrome ? undefined : styles.iconTheme}
       />
       <span>{children}</span>
     </span>

--- a/src/components/laikit/LinkCard/index.tsx
+++ b/src/components/laikit/LinkCard/index.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import Card from '@site/src/components/laikit/Card';
+import IconBlock from '@site/src/components/laikit/IconBlock';
+import styles from './styles.module.css';
+
+type LinkCardLinkProps =
+  | { to: string; href?: never }
+  | { href: string; to?: never };
+
+type LinkCardProps = LinkCardLinkProps & {
+  title: string;
+  description?: string;
+  image?: string;
+  fallbackIcon?: string;
+  /** 'icon' = small centered glyph (e.g. favicon); 'avatar' = fills the block (e.g. profile photo). */
+  imageVariant?: 'icon' | 'avatar';
+};
+
+const ICON_BOX_SIZE = 48;
+const FALLBACK_ICON_SIZE = 24;
+
+export default function LinkCard({
+  title,
+  description,
+  image,
+  fallbackIcon,
+  imageVariant = 'icon',
+  ...linkProps
+}: LinkCardProps) {
+  const [imageError, setImageError] = useState(false);
+  const showImage = !!image && !imageError;
+
+  return (
+    <Card
+      {...linkProps}
+      className={styles.linkCard}
+      wrapperClassName={styles.linkCardWrap}
+      title={title}
+    >
+      {showImage ? (
+        <IconBlock variant="muted" size={ICON_BOX_SIZE}>
+          <img
+            src={image}
+            alt={title}
+            className={
+              imageVariant === 'avatar' ? styles.imageAvatar : styles.image
+            }
+            onError={() => setImageError(true)}
+          />
+        </IconBlock>
+      ) : (
+        <IconBlock
+          icon={fallbackIcon}
+          variant="muted"
+          size={ICON_BOX_SIZE}
+          iconSize={FALLBACK_ICON_SIZE}
+        />
+      )}
+      <div className={styles.body}>
+        <h3 className={styles.title}>{title}</h3>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+    </Card>
+  );
+}

--- a/src/components/laikit/LinkCard/styles.module.css
+++ b/src/components/laikit/LinkCard/styles.module.css
@@ -1,0 +1,72 @@
+.linkCardWrap {
+  height: 100%;
+  animation: linkCardFadeIn 0.3s ease-out;
+}
+
+.linkCard {
+  padding: 1.5rem;
+  min-height: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  box-sizing: border-box;
+  position: relative;
+  overflow: hidden;
+}
+
+.image {
+  width: 24px;
+  height: 24px;
+  object-fit: contain;
+}
+
+.imageAvatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0 0 0.5rem 0;
+  color: var(--ifm-font-color-base);
+  line-height: 1.3;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.description {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+  line-height: 1.5;
+
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 480px) {
+  .linkCard {
+    padding: 1rem;
+  }
+}
+
+@keyframes linkCardFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/pages/_components/Blog/index.tsx
+++ b/src/pages/_components/Blog/index.tsx
@@ -56,7 +56,7 @@ const BlogCard = React.memo<ProcessedBlogPost & { locale: string }>(
             </header>
             <footer>
               <div className={styles.cardMeta}>
-                <IconText icon="lucide:calendar" colorMode="monochrome">
+                <IconText icon="lucide:calendar" monochrome>
                   <time className={styles.time} dateTime={date}>
                     {formattedDate}
                   </time>
@@ -151,7 +151,7 @@ export default function Blog() {
 
             <div className={styles.posts}>
               <p className={styles.postsHeading}>
-                <IconText icon="lucide:chevron-right" colorMode="monochrome">
+                <IconText icon="lucide:chevron-right" monochrome>
                   <Translate id="home.blog.latest">Latest Posts</Translate>
                 </IconText>
               </p>

--- a/src/pages/_components/FourierTransform/styles.module.css
+++ b/src/pages/_components/FourierTransform/styles.module.css
@@ -1,6 +1,6 @@
 .container {
   width: 100%;
-  max-width: 540px;
+  max-width: 500px;
   margin: 0 auto;
   display: flex;
   justify-content: center;

--- a/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
+++ b/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
@@ -394,7 +394,7 @@ function Neurons({
               r={8}
               stroke={
                 isSelected
-                  ? 'var(--nn-neuron-border-selected)'
+                  ? 'var(--ifm-color-primary)'
                   : 'var(--nn-neuron-border-default)'
               }
               strokeWidth={isSelected ? 2 : 1}
@@ -439,7 +439,7 @@ function WinningOutputNeuronBox({
       y={pos.y - 12}
       width={w}
       height={h}
-      stroke="var(--nn-stroke-accent)"
+      stroke="var(--ifm-color-primary)"
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
@@ -604,7 +604,7 @@ function ImageGrid({
             width={400 / 28}
             height={400 / 28}
             fill={`rgba(var(--nn-grid-white-rgb), ${value})`}
-            stroke={highlightedTile === n ? 'var(--nn-stroke-accent)' : 'none'}
+            stroke={highlightedTile === n ? 'var(--ifm-color-primary)' : 'none'}
             strokeWidth="2"
           />
         ))}
@@ -629,7 +629,7 @@ function ImageGrid({
           y={50}
           dominantBaseline="middle"
           textAnchor="middle"
-          fill="var(--nn-text-accent)"
+          fill="var(--ifm-color-primary)"
           fontFamily="sans-serif"
           fontSize={36}
         >
@@ -642,7 +642,7 @@ function ImageGrid({
         y={0}
         width={400}
         height={400}
-        stroke="var(--nn-stroke-subtle)"
+        stroke="var(--ifm-color-emphasis-300)"
         strokeWidth="1"
         rx="2"
         fill="var(--nn-transparent)"
@@ -700,7 +700,7 @@ function WeightGrid({
           width="30"
           height="30"
           fill="var(--nn-grid-fill)"
-          stroke="var(--nn-grid-stroke)"
+          stroke="var(--ifm-color-primary)"
           strokeWidth="0.5"
         />
       ))}

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -6,9 +6,7 @@
 
   --nn-text-primary: #ffffff;
   --nn-text-secondary: #000000;
-  --nn-text-accent: var(--ifm-color-primary);
 
-  --nn-neuron-border-selected: var(--ifm-color-primary);
   --nn-neuron-border-default: #ffffff;
   --nn-neuron-fill-default: #000000;
 
@@ -22,12 +20,8 @@
   --nn-connection-animation: rgba(var(--ifm-color-primary-rgb), 0.55);
   --nn-connection-default: #666666;
 
-  --nn-stroke-accent: var(--ifm-color-primary);
-  --nn-stroke-subtle: var(--ifm-color-emphasis-300);
-
   --nn-grid-white: #ffffff;
   --nn-grid-white-rgb: 255, 255, 255;
-  --nn-grid-stroke: var(--ifm-color-primary);
   --nn-grid-fill: #000000;
 
   width: 100%;
@@ -81,14 +75,13 @@
 
 .controls {
   position: absolute;
-  left: 0;
-  right: 0;
+  left: 14%;
+  right: 14%;
   bottom: 8%;
   display: flex;
   gap: 0.85rem;
   justify-content: center;
   align-items: stretch;
-  padding: 0 1.5rem;
   opacity: 1;
   pointer-events: auto;
   transition:

--- a/src/pages/blog/moments/index.tsx
+++ b/src/pages/blog/moments/index.tsx
@@ -34,7 +34,7 @@ export default function moments() {
           )}
           <hr className={styles.hr} />
           <div className={styles.momentMeta}>
-            <IconText icon="lucide:calendar" colorMode="monochrome">
+            <IconText icon="lucide:calendar" monochrome>
               {new Date(moment.date).toLocaleDateString('en-US', {
                 year: 'numeric',
                 month: 'long',

--- a/src/pages/friends/index.tsx
+++ b/src/pages/friends/index.tsx
@@ -1,9 +1,8 @@
-import React, { type ReactNode, useState } from 'react';
+import React, { type ReactNode } from 'react';
 import Layout from '@theme/Layout';
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
-import Card from '@site/src/components/laikit/Card';
-import IconBlock from '@site/src/components/laikit/IconBlock';
+import LinkCard from '@site/src/components/laikit/LinkCard';
 import { FriendItem, FRIEND_LIST } from '@site/src/data/friends';
 import { translate } from '@docusaurus/Translate';
 import styles from './styles.module.css';
@@ -22,41 +21,15 @@ const MODIFICATION = translate({
 });
 
 function FriendCard({ friend }: { friend: FriendItem }) {
-  const [imageError, setImageError] = useState(false);
-
   return (
-    <Card
+    <LinkCard
       href={friend.href}
-      wrapperClassName={styles.friendCard}
-      className={styles.friendCardContent}
-      padding="1.5rem"
-    >
-      <div className={styles.friendCardHeader}>
-        {!imageError && friend.avatar ? (
-          <IconBlock variant="muted" size={60}>
-            <img
-              src={friend.avatar}
-              alt={friend.title}
-              className={styles.friendCardImage}
-              onError={() => setImageError(true)}
-            />
-          </IconBlock>
-        ) : (
-          <IconBlock
-            icon="lucide:user"
-            variant="muted"
-            size={60}
-            iconSize={24}
-          />
-        )}
-        <div className={styles.friendCardInfo}>
-          <h3 className={styles.friendCardTitle}>{friend.title}</h3>
-          <p className={styles.friendCardDescription}>
-            {friend.description ?? friend.href}
-          </p>
-        </div>
-      </div>
-    </Card>
+      title={friend.title}
+      description={friend.description ?? friend.href}
+      image={friend.avatar}
+      imageVariant="avatar"
+      fallbackIcon="lucide:user"
+    />
   );
 }
 

--- a/src/pages/friends/styles.module.css
+++ b/src/pages/friends/styles.module.css
@@ -11,56 +11,6 @@
   padding: 2rem;
 }
 
-/* Friend card */
-
-.friendCard {
-  height: 100%;
-}
-
-.friendCardContent {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.friendCardHeader {
-  display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-}
-
-.friendCardImage {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.friendCardInfo {
-  flex: 1;
-  min-width: 0;
-}
-
-.friendCardTitle {
-  font-size: 1.2rem;
-  font-weight: 600;
-  margin: 0 0 0.5rem 0;
-  color: var(--ifm-font-color-base);
-  line-height: 1.3;
-}
-
-.friendCardDescription {
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-700);
-  margin: 0;
-  line-height: 1.5;
-  display: -webkit-box;
-  line-clamp: 1;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
 /* Responsive */
 
 @media (max-width: 1199px) {
@@ -71,34 +21,6 @@
 
 @media (max-width: 768px) {
   .container {
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
     padding: 1rem;
   }
-
-  .friendCardHeader {
-    flex-direction: column;
-    text-align: center;
-    align-items: center;
-  }
-
-  .friendCardInfo {
-    width: 100%;
-  }
-}
-
-/* Animations */
-
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(8px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.friendCard {
-  animation: fadeIn 0.3s ease-out;
 }

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -1,12 +1,10 @@
 import React, { type ReactNode, useState, useMemo } from 'react';
 import { Icon } from '@iconify/react';
-import clsx from 'clsx';
 import Layout from '@theme/Layout';
 
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
-import Card from '@site/src/components/laikit/Card';
-import IconBlock from '@site/src/components/laikit/IconBlock';
+import LinkCard from '@site/src/components/laikit/LinkCard';
 import IconText from '@site/src/components/laikit/IconText';
 import Button from '@site/src/components/laikit/Button';
 
@@ -96,9 +94,9 @@ function CategoryNav({
       <div className={styles.categoryNavContent}>
         <Button
           variant="secondary"
+          size="sm"
           rounded
           active={activeCategory === 'all'}
-          className={styles.categoryButton}
           onClick={() => onCategoryChange('all')}
         >
           {translate({
@@ -110,9 +108,9 @@ function CategoryNav({
           <Button
             key={category.title}
             variant="secondary"
+            size="sm"
             rounded
             active={activeCategory === category.title}
-            className={styles.categoryButton}
             onClick={() => onCategoryChange(category.title)}
           >
             {category.title}
@@ -129,37 +127,14 @@ function ResourceCard({
   resource: { title: string; description: string; href: string };
 }) {
   const iconUrl = `https://www.google.com/s2/favicons?sz=64&domain=${new URL(resource.href).hostname}`;
-  const [imageError, setImageError] = useState(false);
-
   return (
-    <Card
+    <LinkCard
       to={resource.href}
-      className={styles.resourceCard}
-      wrapperClassName={styles.resourceCardLink}
       title={resource.title}
-    >
-      {imageError ? (
-        <IconBlock
-          icon="lucide:globe"
-          variant="muted"
-          size={48}
-          iconSize={24}
-        />
-      ) : (
-        <IconBlock variant="muted" size={48}>
-          <img
-            src={iconUrl}
-            alt={resource.title}
-            className={styles.resourceCardImage}
-            onError={() => setImageError(true)}
-          />
-        </IconBlock>
-      )}
-      <div className={styles.resourceCardBody}>
-        <h3 className={styles.resourceCardTitle}>{resource.title}</h3>
-        <p className={styles.resourceCardDescription}>{resource.description}</p>
-      </div>
-    </Card>
+      description={resource.description}
+      image={iconUrl}
+      fallbackIcon="lucide:globe"
+    />
   );
 }
 

--- a/src/pages/resources/styles.module.css
+++ b/src/pages/resources/styles.module.css
@@ -59,10 +59,6 @@
   justify-content: center;
 }
 
-.categoryButton:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-}
-
 /* Category sections & resource grid */
 
 .categorySection {
@@ -101,56 +97,6 @@
   gap: 1.5rem;
 }
 
-/* Resource card */
-
-.resourceCard {
-  padding: 1.5rem;
-  min-height: 100%;
-  display: flex;
-  align-items: flex-start;
-  gap: 1rem;
-  box-sizing: border-box;
-  position: relative;
-  overflow: hidden;
-}
-
-.resourceCardLink {
-  height: 100%;
-}
-
-.resourceCardImage {
-  width: 24px;
-  height: 24px;
-  object-fit: contain;
-}
-
-.resourceCardBody {
-  flex: 1;
-  min-width: 0;
-}
-
-.resourceCardTitle {
-  font-size: 1.1rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem 0;
-  color: var(--ifm-font-color-base);
-  line-height: 1.3;
-
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.resourceCardDescription {
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-700);
-  margin: 0;
-  line-height: 1.5;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 /* Empty / fallback state */
 
 .noResults {
@@ -174,15 +120,6 @@
     align-items: flex-start;
     gap: 1rem;
   }
-
-  .categoryButton {
-    padding: 0.5rem 1rem;
-    font-size: 0.85rem;
-  }
-
-  .resourceCard {
-    padding: 1rem;
-  }
 }
 
 /* Animations */
@@ -199,9 +136,5 @@
 }
 
 .categorySection {
-  animation: fadeIn 0.3s ease-out;
-}
-
-.resourceCard {
   animation: fadeIn 0.3s ease-out;
 }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -145,11 +145,8 @@ function AccentColor() {
         </div>
         <div className={styles.presetColors}>
           {SETTINGS_PRESET_COLOR_LIST.map((color) => (
-            <Button
+            <button
               key={color}
-              variant="ghost"
-              rounded
-              aria-label={color}
               className={styles.presetColorButton}
               style={{
                 background: `linear-gradient(to right, ${color} 0 50%, ${Color(color).mix(Color('#fff'), 0.3).hex()} 50% 100%)`,

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -145,14 +145,13 @@
 .presetColorButton {
   width: 28px;
   height: 28px;
-  min-height: 0;
-  padding: 0;
   border: 0;
+  border-radius: 50%;
+  cursor: pointer;
   transition: transform 0.2s;
 }
 
 .presetColorButton:hover {
-  background: inherit !important;
   transform: scale(1.1);
 }
 

--- a/src/theme/BlogShared/PostsListLayout.tsx
+++ b/src/theme/BlogShared/PostsListLayout.tsx
@@ -47,7 +47,7 @@ function IconData({ icon, children }: IconDataProps) {
   return (
     <>
       <span className={styles.dot}>|</span>
-      <IconText icon={icon} colorMode="monochrome">
+      <IconText icon={icon} monochrome>
         {children}
       </IconText>
     </>
@@ -90,7 +90,7 @@ function PostCard({ item }: PostCardProps) {
         </MDXContent>
       </div>
       <div className={styles.postMeta}>
-        <IconText icon="lucide:calendar" colorMode="monochrome">
+        <IconText icon="lucide:calendar" monochrome>
           <time dateTime={metadata.date}>{metadata.date.slice(0, 10)}</time>
         </IconText>
         {!!metadata.readingTime && (

--- a/src/theme/Root/CookieConsent/index.tsx
+++ b/src/theme/Root/CookieConsent/index.tsx
@@ -43,7 +43,7 @@ export default function CookieConsent() {
       aria-live="polite"
       aria-label="Cookie consent"
     >
-      <Card padding="1.25rem" className={styles.card}>
+      <Card padding="1.25rem">
         <div className={styles.content}>
           <div className={styles.title}>
             <Translate id="cookieConsent.title">Cookie Settings</Translate>

--- a/src/theme/Root/CookieConsent/styles.module.css
+++ b/src/theme/Root/CookieConsent/styles.module.css
@@ -8,14 +8,6 @@
   animation: cookieConsentIn 200ms ease-out;
 }
 
-.card {
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
-}
-
-html[data-theme='dark'] .card {
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
-}
-
 .content {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
This PR pulls a number of cards/components closer to the laikit design system, removing redundant local overrides and adding one new primitive.

### What's new
- **`laikit/LinkCard`** — a clickable image + title + description tile. Two variants: `imageVariant="icon"` (default, small centered glyph like a favicon) and `imageVariant="avatar"` (full-bleed profile photo). Resources and friends pages both migrate to it; ~140 lines of duplicated CSS go away.

### What got cleaner
- **`BrowserWindow`** now wraps `<Card>` directly. The duplicated background / border / border-radius / box-shadow (and the dark-mode border override) are gone — it inherits the same surface as every other card.
- **`CookieConsent`** drops its custom popover-shadow override on Card; one less magic value floating around.
- **`NeuralNetwork`** replaces the five pure-alias `--nn-*` CSS variables with `--ifm-*` references where the colors are identical (semantic ones — varied by theme — stayed). Canvas width aligned to 500px to match Fourier/Lorenz, and the Clear/Check buttons now snap to the drawing-pad's left/right edges. Also added the missing zh-Hans translations for the three button labels.
- **`IconText`** API: `colorMode="monochrome"` → boolean `monochrome` (default `false`). 5 call sites updated.
- **Resources page**: deleted the `.categoryButton:hover` box-shadow (Button's `secondary` variant already provides hover feedback); category buttons now use `size="sm"` instead of a mobile-only padding/font-size override.
- **Settings**: `.presetColorButton` reverted to a native `<button>`. It was forcing Button's size system to render as 28×28 swatches, which is a misuse — swatches are decorative shapes, not buttons.
- **Fourier canvas** `max-width` 540 → 500 so all three home canvases (Fourier / Lorenz / NeuralNetwork) line up.

### Notes for reviewers
- Friend cards now use the unified 48×48 IconBlock instead of the previous 60px, but `imageVariant="avatar"` keeps the avatar full-bleed via `object-fit: cover`. Visually similar density to before, slightly tighter.
- BrowserWindow's border-radius changes 12px → 16px (Card's value). This is intentional — it joins the surface family.
- Laikit `Card` itself is unchanged. All consolidation is via existing props (`padding`, `className`, `wrapperClassName`).

## Test plan
- [ ] `/zh-Hans/resources` — favicons render small/centered, hover changes border color (not shadow), 480px breakpoint padding still drops to 1rem.
- [ ] `/zh-Hans/friends` — avatars fill 48×48, fallback `lucide:user` icon shows when avatar URL fails.
- [ ] `/zh-Hans/` — three home canvases all 500×500, NeuralNetwork Clear/Check buttons aligned with drawing pad.
- [ ] Any docs page with `<BrowserWindow>` — frame still renders, header magnifier dots intact, body content unaffected.
- [ ] `/zh-Hans/settings` — color preset swatches still 28×28 circles, hover scales 1.1x.
- [ ] Cookie consent banner (clear localStorage `cookie-consent` to trigger) — renders, looks like a normal Card now.
- [ ] Light / dark mode parity for all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)