### PR TITLE
Replace hardcoded Umami auth and fix settings reset button

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -985,5 +985,14 @@
   },
   "pages.settings.item.language.description": {
     "message": "切换界面语言"
+  },
+  "home.neuralnetwork.clear": {
+    "message": "Clear"
+  },
+  "home.neuralnetwork.check": {
+    "message": "Check digit"
+  },
+  "home.neuralnetwork.preprocess": {
+    "message": "Pre-process"
   }
 }

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import { umamiFetchJson } from '@site/src/utils/umami';
+
+export interface AnalyticsData {
+  visitors?: number;
+  pageviews?: number;
+}
+
+export type AnalyticsStatus = 'loading' | 'success' | 'error';
+
+interface UmamiStatsResponse {
+  pageviews?: number;
+  visitors?: number;
+  visits?: number;
+  bounces?: number;
+  totaltime?: number;
+}
+
+export function useAnalytics(rawPath: string = '') {
+  const [analytics, setAnalytics] = useState<AnalyticsData>({});
+  const [status, setStatus] = useState<AnalyticsStatus>('loading');
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    (async () => {
+      setStatus('loading');
+      try {
+        const data = await umamiFetchJson<UmamiStatsResponse>(
+          '/api/websites/{id}/stats',
+          {
+            startAt: 0,
+            endAt: Date.now(),
+            ...(rawPath ? { path: rawPath } : {}),
+          },
+          { signal: controller.signal }
+        );
+
+        if (controller.signal.aborted) return;
+
+        setAnalytics({
+          visitors: data.visitors,
+          pageviews: data.pageviews,
+        });
+        setStatus('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error(error);
+        setStatus('error');
+      }
+    })();
+
+    return () => controller.abort();
+  }, [rawPath]);
+
+  return { analytics, status };
+}

--- a/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
+++ b/src/pages/_components/NeuralNetwork/NeuralNetworkInteractive.tsx
@@ -137,7 +137,9 @@ export default function NeuralNetworkInteractive({
   const isEmpty = !inputValues.some((v) => v > 0.1);
 
   if (!dataLoaded) {
-    return <div className={styles.container} style={{ minHeight: CANVAS_SIZE }} />;
+    return (
+      <div className={styles.container} style={{ minHeight: CANVAS_SIZE }} />
+    );
   }
 
   const compact = animating || instant;
@@ -146,89 +148,89 @@ export default function NeuralNetworkInteractive({
   return (
     <div className={styles.container}>
       <div className={styles.frame}>
-      <svg
-        className={styles.svg}
-        width={CANVAS_SIZE}
-        height={CANVAS_SIZE}
-        viewBox={`0 0 ${CANVAS_SIZE} ${CANVAS_SIZE}`}
-        style={{ touchAction: 'none' }}
-      >
-        <NeuronConnections
-          selectedNeuron={selectedNeuron}
-          animating={animating}
-          instant={instant}
-        />
-        <VerticalEllipsis cx={175} cy={CANVAS_CENTER} />
-        <Neurons
-          neurons={neurons}
-          selectedNeuron={selectedNeuron}
-          setSelectedNeuron={setSelectedNeuron}
-          animating={animating}
-          instant={instant}
-        />
-        <OutputDigitLabels />
-        <WinningOutputNeuronBox
-          neurons={neurons}
-          animating={animating}
-          instant={instant}
-        />
-
-        {selectedNeuron?.layerIndex === 1 &&
-          (() => {
-            const pos = getNeuronPosition(
-              selectedNeuron.layerIndex,
-              selectedNeuron.neuronId
-            );
-            return (
-              <WeightGrid
-                x={pos.x + 14}
-                y={-30 + (pos.y - CANVAS_CENTER) * 0.85 + CANVAS_CENTER}
-                width={65}
-                height={65}
-                weights={weights![0][selectedNeuron.neuronId]}
-                inputNeurons={neurons[0]}
-              />
-            );
-          })()}
-
-        {!instant && (
-          <rect
-            x="0"
-            y="0"
-            width={CANVAS_SIZE}
-            height={CANVAS_SIZE}
-            fill="var(--ifm-background-color)"
-            style={{
-              opacity: animating ? 0 : 1,
-              pointerEvents: animating ? 'none' : undefined,
-              transition: 'opacity 300ms ease-in-out',
-            }}
+        <svg
+          className={styles.svg}
+          width={CANVAS_SIZE}
+          height={CANVAS_SIZE}
+          viewBox={`0 0 ${CANVAS_SIZE} ${CANVAS_SIZE}`}
+          style={{ touchAction: 'none' }}
+        >
+          <NeuronConnections
+            selectedNeuron={selectedNeuron}
+            animating={animating}
+            instant={instant}
           />
-        )}
+          <VerticalEllipsis cx={175} cy={CANVAS_CENTER} />
+          <Neurons
+            neurons={neurons}
+            selectedNeuron={selectedNeuron}
+            setSelectedNeuron={setSelectedNeuron}
+            animating={animating}
+            instant={instant}
+          />
+          <OutputDigitLabels />
+          <WinningOutputNeuronBox
+            neurons={neurons}
+            animating={animating}
+            instant={instant}
+          />
 
-        <ImageGrid
-          editing={editing}
-          startEditing={() => {
-            setAnimating(false);
-            setPoints([]);
-            setIsNormalized(false);
-          }}
-          x={compact ? 10 : 70}
-          y={compact ? 10 : 30}
-          width={compact ? 130 : 360}
-          height={compact ? 130 : 360}
-          points={points}
-          inputValues={inputValues}
-          setPoints={(newPoints) => {
-            setPoints(newPoints);
-            setIsNormalized(false);
-          }}
-          normalizing={normalizing}
-          highlightedTile={
-            selectedNeuron?.layerIndex === 0 ? selectedNeuron.neuronId : null
-          }
-        />
-      </svg>
+          {selectedNeuron?.layerIndex === 1 &&
+            (() => {
+              const pos = getNeuronPosition(
+                selectedNeuron.layerIndex,
+                selectedNeuron.neuronId
+              );
+              return (
+                <WeightGrid
+                  x={pos.x + 14}
+                  y={-30 + (pos.y - CANVAS_CENTER) * 0.85 + CANVAS_CENTER}
+                  width={65}
+                  height={65}
+                  weights={weights![0][selectedNeuron.neuronId]}
+                  inputNeurons={neurons[0]}
+                />
+              );
+            })()}
+
+          {!instant && (
+            <rect
+              x="0"
+              y="0"
+              width={CANVAS_SIZE}
+              height={CANVAS_SIZE}
+              fill="var(--ifm-background-color)"
+              style={{
+                opacity: animating ? 0 : 1,
+                pointerEvents: animating ? 'none' : undefined,
+                transition: 'opacity 300ms ease-in-out',
+              }}
+            />
+          )}
+
+          <ImageGrid
+            editing={editing}
+            startEditing={() => {
+              setAnimating(false);
+              setPoints([]);
+              setIsNormalized(false);
+            }}
+            x={compact ? 10 : 70}
+            y={compact ? 10 : 30}
+            width={compact ? 130 : 360}
+            height={compact ? 130 : 360}
+            points={points}
+            inputValues={inputValues}
+            setPoints={(newPoints) => {
+              setPoints(newPoints);
+              setIsNormalized(false);
+            }}
+            normalizing={normalizing}
+            highlightedTile={
+              selectedNeuron?.layerIndex === 0 ? selectedNeuron.neuronId : null
+            }
+          />
+        </svg>
 
         <div
           className={clsx(styles.controls, !editing && styles.controlsHidden)}

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -256,11 +256,7 @@ function ResourcesMain() {
               { query: searchQuery }
             )}
           </p>
-          <Button
-            variant="primary"
-            rounded
-            onClick={() => setSearchQuery('')}
-          >
+          <Button variant="primary" rounded onClick={() => setSearchQuery('')}>
             {translate({
               id: 'pages.resources.noresults.clear',
               message: 'Clear Search',

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -156,8 +156,11 @@
   transform: scale(1.1);
 }
 
-.resetButton {
+/* Doubled class to outweigh Button's .size_sm height. */
+.resetButton.resetButton {
   flex-shrink: 0;
+  height: auto;
+  align-self: stretch;
 }
 
 /* Typography sliders */

--- a/src/theme/BlogShared/Components.tsx
+++ b/src/theme/BlogShared/Components.tsx
@@ -4,10 +4,11 @@ import Link from '@docusaurus/Link';
 import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
-const WEBSITE_ID = '69d3b7de-90e4-4be4-a355-633620ecefdb';
-const ANALYTICS_BASE_URL = `https://analytics.lailai.one/api/websites/${WEBSITE_ID}/stats`;
-const Authorization =
-  'Bearer mXASurmA0JxF4bm+aeWM458Rk3hKZJUoYm4aSFdVUp1LzlZ96vwe2RcV6b19yqwgwmPIo3q2jvqLlBqLhNrkW+AlPZ/CgTIfAkeMrg+NWpcYD9waQRngwntf5maKEt/oBwKm9C3wd3dCm7m0BSXddT8q8vDMYSRYeJ+tcwkcbEOCtsgAHs28V+qT30mGz6yCh02gctP3RrPDeIvq3A4az1n87MlUZDiLxI8YwX8aVhSOml6WKnKtFOWgqTCXt9si79sLuw8vWT+FySCkes47gl0JlgOz/gFGZPwCGa2LKP1N0evzma5tvUtKLJsQfcBp/JZVoxDRmMUp2B1PaKoUyAn4ELxQzLpaFkVyMdA/p1AO72N2vhlNHILC4/kI';
+export { useAnalytics } from '@site/src/hooks/useAnalytics';
+export type {
+  AnalyticsData,
+  AnalyticsStatus,
+} from '@site/src/hooks/useAnalytics';
 
 export function BlogCard({
   title,
@@ -67,45 +68,4 @@ export function formatLongNumber(
     compactDisplay: 'short',
     maximumSignificantDigits: 3,
   }).format(n);
-}
-
-export function useAnalytics(rawPath: string = '') {
-  const [analytics, setAnalytics] = React.useState<{
-    visitors?: number;
-    pageviews?: number;
-  }>({});
-  const [status, setStatus] = React.useState<'loading' | 'success' | 'error'>(
-    'loading'
-  );
-
-  React.useEffect(() => {
-    const controller = new AbortController();
-    const query = rawPath ? `&path=eq.${encodeURIComponent(rawPath)}` : '';
-
-    (async () => {
-      setStatus('loading');
-      try {
-        const res = await fetch(
-          `${ANALYTICS_BASE_URL}?startAt=0&endAt=${Date.now()}${query}`,
-          {
-            signal: controller.signal,
-            headers: { Authorization },
-          }
-        );
-
-        if (!res.ok) throw new Error(`Stats request failed: ${res.status}`);
-
-        setAnalytics(await res.json());
-        setStatus('success');
-      } catch (error) {
-        if (controller.signal.aborted) return;
-        console.error(error);
-        setStatus('error');
-      }
-    })();
-
-    return () => controller.abort();
-  }, [rawPath]);
-
-  return { analytics, status };
 }

--- a/src/utils/umami.ts
+++ b/src/utils/umami.ts
@@ -1,0 +1,126 @@
+const UMAMI_BASE = 'https://analytics.lailai.one';
+const UMAMI_SHARE_SLUG = 'DDd09iBEYOQw2k9L';
+
+const SESSION_STORAGE_KEY = 'umami_share_session_v1';
+const SESSION_TTL_MS = 60 * 60 * 1000;
+
+export interface ShareSession {
+  token: string;
+  websiteId: string;
+}
+
+interface CachedSession {
+  data: ShareSession;
+  expiresAt: number;
+}
+
+let pendingSession: Promise<ShareSession> | null = null;
+
+function readSessionCache(): ShareSession | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) return null;
+    const cached = JSON.parse(raw) as CachedSession;
+    if (
+      !cached ||
+      typeof cached.expiresAt !== 'number' ||
+      cached.expiresAt <= Date.now() ||
+      !cached.data?.token ||
+      !cached.data?.websiteId
+    ) {
+      return null;
+    }
+    return cached.data;
+  } catch {
+    return null;
+  }
+}
+
+function writeSessionCache(data: ShareSession): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const cached: CachedSession = {
+      data,
+      expiresAt: Date.now() + SESSION_TTL_MS,
+    };
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(cached));
+  } catch {
+    // sessionStorage may be unavailable
+  }
+}
+
+async function fetchShareSession(): Promise<ShareSession> {
+  const res = await fetch(
+    `${UMAMI_BASE}/api/share/${encodeURIComponent(UMAMI_SHARE_SLUG)}`
+  );
+  if (!res.ok) {
+    throw new Error(`Umami share session request failed: ${res.status}`);
+  }
+  const data = (await res.json()) as Partial<ShareSession>;
+  if (!data.token || !data.websiteId) {
+    throw new Error('Umami share session response missing token or websiteId');
+  }
+  const session: ShareSession = {
+    token: data.token,
+    websiteId: data.websiteId,
+  };
+  writeSessionCache(session);
+  return session;
+}
+
+export async function getShareSession(): Promise<ShareSession> {
+  const cached = readSessionCache();
+  if (cached) return cached;
+  if (pendingSession) return pendingSession;
+
+  pendingSession = fetchShareSession().finally(() => {
+    pendingSession = null;
+  });
+  return pendingSession;
+}
+
+type SearchParamValue = string | number | boolean | undefined | null;
+
+function buildSearch(params?: Record<string, SearchParamValue>): string {
+  if (!params) return '';
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined && v !== null && v !== ''
+  );
+  if (entries.length === 0) return '';
+  const usp = new URLSearchParams();
+  for (const [k, v] of entries) {
+    usp.set(k, String(v));
+  }
+  return `?${usp.toString()}`;
+}
+
+export async function umamiFetch(
+  pathTemplate: string,
+  params?: Record<string, SearchParamValue>,
+  init?: Omit<RequestInit, 'headers'>
+): Promise<Response> {
+  const session = await getShareSession();
+  const path = pathTemplate.replace('{id}', session.websiteId);
+  const url = `${UMAMI_BASE}${path}${buildSearch(params)}`;
+
+  return fetch(url, {
+    ...init,
+    headers: {
+      'x-umami-share-token': session.token,
+      'x-umami-share-context': '1',
+    },
+  });
+}
+
+export async function umamiFetchJson<T>(
+  pathTemplate: string,
+  params?: Record<string, SearchParamValue>,
+  init?: Omit<RequestInit, 'headers'>
+): Promise<T> {
+  const res = await umamiFetch(pathTemplate, params, init);
+  if (!res.ok) {
+    throw new Error(`Umami request failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}


### PR DESCRIPTION
## Summary

- Replace the hardcoded long-lived Umami account session token in the blog theme with a share-token flow (`/api/share/<slug>` → token, cached in sessionStorage, sent as `x-umami-share-token` + `x-umami-share-context: 1` per Umami v3 conventions).
- Fix the Accent Color card's **Reset** button so it matches the color field's height instead of being visibly shorter.

## Why

The blog theme used to embed a hardcoded `Authorization: Bearer …` token in `BlogShared/Components.tsx`. After tracing it through Umami v3 source, that token is an account-level session token (not a public share token). Once committed to a public repo, it grants any reader full account-level access to the self-hosted Umami instance for the lifetime of the `APP_SECRET`. The new flow only ever fetches a read-only share token at runtime, scoped to the single shared website.

Per-post view counts also relied on `path=eq.<value>` (PostgREST-style filtering, never matched on Umami v3 `filterParams`). Switching to plain `path=<value>` makes per-post counts show real numbers instead of always returning site totals.

The Reset button mismatch was a small visual bug after migrating that button to `laikit/Button` `size="sm"`: 32 px button vs 38 px color field. Fixed with `align-self: stretch` + `height: auto`, doubled-class to outweigh Button's own size rule, so it tracks the field height without hardcoded pixels.

## Reviewer notes

- `useAnalytics(rawPath?)` keeps the same external signature; `Scaffold.tsx` and `PostsListLayout.tsx` aren't touched.
- The leaked token is still in git history. To fully revoke it, change Umami's `APP_SECRET` env var (logs everyone out, including admin), then redeploy. Changing the admin password alone does **not** invalidate existing secure tokens in v3.1.0.
- The second commit is collateral from running `npm run check`: Prettier reflowed two unrelated multi-line blocks (NeuralNetwork, resources) and `write-translations` added three missing zh-Hans keys (still English defaults — translation pending).

## Test plan

- [ ] `/blog` sidebar Stats card shows real Visitors / Views numbers.
- [ ] Each post card on `/blog` shows its real view count (was always 0/total before).
- [ ] DevTools Network: a single `GET /api/share/DDd09iBEYOQw2k9L` (200), then `GET /api/websites/<id>/stats` calls with `x-umami-share-token` + `x-umami-share-context: 1` (no `Authorization` header).
- [ ] `/settings` Accent Color card: Reset button height matches the color field height in both light/dark themes.
- [ ] `npm run check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)