### PR TITLE
Reorder i18n/zh-Hans/code.json keys

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -1,4 +1,442 @@
 {
+  "home.scrollGuide": {
+    "message": "向下滚动"
+  },
+  "data.changelog.type.added": {
+    "message": "【新增】"
+  },
+  "data.changelog.type.changed": {
+    "message": "【变更】"
+  },
+  "data.changelog.type.deprecated": {
+    "message": "【弃用】"
+  },
+  "data.changelog.type.removed": {
+    "message": "【移除】"
+  },
+  "data.changelog.type.fixed": {
+    "message": "【修复】"
+  },
+  "data.changelog.type.security": {
+    "message": "【安全】"
+  },
+  "data.devices.macbook-pro.spec": {
+    "message": "16 英寸 / 银色 / 14 CPU / 30 GPU / 36GB / 1TB"
+  },
+  "data.devices.ipad-pro.spec": {
+    "message": "11 英寸 / 深空灰色 / 256GB"
+  },
+  "data.devices.iphone.spec": {
+    "message": "星光色 / A15 / 256GB"
+  },
+  "data.devices.apple-watch.spec": {
+    "message": "钛合金 / 石板色 / 46mm / S10"
+  },
+  "data.devices.airpods-pro.spec": {
+    "message": "USB-C / H2 / U1"
+  },
+  "data.devices.airpods-max.spec": {
+    "message": "USB-C / 午夜色 / H1"
+  },
+  "data.devices.powerbeats-pro.spec": {
+    "message": "极速黑 / H2"
+  },
+  "components.problem.code": {
+    "message": "代码（{num}）"
+  },
+  "components.problem.solution": {
+    "message": "题解"
+  },
+  "components.problem.error": {
+    "message": "无法加载题目「{id}」。"
+  },
+  "components.solution.luogu": {
+    "message": "洛谷"
+  },
+  "components.solution.blog": {
+    "message": "博客"
+  },
+  "components.solution.solution": {
+    "message": "题解"
+  },
+  "pages.friends.title": {
+    "message": "友链"
+  },
+  "pages.friends.description": {
+    "message": "真正的友谊是世上最稀有的东西"
+  },
+  "pages.friends.modification": {
+    "message": "我的<b>友链</b>"
+  },
+  "pages.friends.datacard.label": {
+    "message": "位朋友"
+  },
+  "pages.resources.title": {
+    "message": "资源"
+  },
+  "pages.resources.description": {
+    "message": "精心筛选的优质工具与平台"
+  },
+  "pages.resources.modification": {
+    "message": "精选<b>资源</b>"
+  },
+  "pages.resources.search.placeholder": {
+    "message": "搜索资源"
+  },
+  "pages.resources.category.all": {
+    "message": "全部"
+  },
+  "pages.resources.category.count": {
+    "message": "{count} 项"
+  },
+  "pages.resources.datacard.label1": {
+    "message": "个分类"
+  },
+  "pages.resources.datacard.label2": {
+    "message": "项资源"
+  },
+  "pages.resources.noresults.description": {
+    "message": "找不到和“{query}”相符的资源。"
+  },
+  "pages.resources.noresults.clear": {
+    "message": "清空搜索"
+  },
+  "pages.settings.title": {
+    "message": "设置"
+  },
+  "pages.settings.description": {
+    "message": "自定义网站功能和偏好设置"
+  },
+  "pages.settings.modification": {
+    "message": "个性化<b>设置</b>"
+  },
+  "pages.settings.item.theme.option.system": {
+    "message": "系统模式"
+  },
+  "pages.settings.item.theme.option.light": {
+    "message": "浅色模式"
+  },
+  "pages.settings.item.theme.option.dark": {
+    "message": "深色模式"
+  },
+  "pages.settings.item.theme.title": {
+    "message": "主题"
+  },
+  "pages.settings.item.theme.description": {
+    "message": "切换浅色、深色或跟随系统"
+  },
+  "pages.settings.item.color.title": {
+    "message": "主题色"
+  },
+  "pages.settings.item.color.description": {
+    "message": "自定义网站主色调"
+  },
+  "pages.settings.item.color.picker": {
+    "message": "选择颜色"
+  },
+  "pages.settings.item.color.reset": {
+    "message": "重置"
+  },
+  "pages.settings.item.font.title": {
+    "message": "排版"
+  },
+  "pages.settings.item.font.description": {
+    "message": "调整文字大小与行间距"
+  },
+  "pages.settings.item.font.size.current": {
+    "message": "字体大小：{size}px"
+  },
+  "pages.settings.item.font.lineheight.current": {
+    "message": "行间距：{value}"
+  },
+  "pages.settings.item.experimental.option.originalLayout": {
+    "message": "原版布局"
+  },
+  "pages.settings.item.experimental.option.debugMode": {
+    "message": "调试模式"
+  },
+  "pages.settings.item.experimental.option.grayMode": {
+    "message": "灰色模式"
+  },
+  "pages.settings.item.experimental.title": {
+    "message": "实验性功能"
+  },
+  "pages.settings.item.experimental.description": {
+    "message": "试用开发中的新功能"
+  },
+  "pages.settings.item.quickactions.option.confetti": {
+    "message": "给我惊喜"
+  },
+  "pages.settings.item.quickactions.option.reset": {
+    "message": "重置设置"
+  },
+  "pages.settings.item.quickactions.title": {
+    "message": "快捷操作"
+  },
+  "pages.settings.item.quickactions.description": {
+    "message": "一键执行常用操作"
+  },
+  "pages.settings.datacard.label": {
+    "message": "项设置"
+  },
+  "pages.settings.item.language.title": {
+    "message": "语言"
+  },
+  "pages.settings.item.language.description": {
+    "message": "切换界面语言"
+  },
+  "pages.travel.title": {
+    "message": "旅行"
+  },
+  "pages.travel.description": {
+    "message": "每一次旅行都能带来新的视野和感悟"
+  },
+  "pages.travel.modification": {
+    "message": "旅行<b>记录</b>"
+  },
+  "pages.travel.datacard.label1": {
+    "message": "国家/地区"
+  },
+  "pages.travel.datacard.label2": {
+    "message": "年历程"
+  },
+  "theme.blog.archive.title": {
+    "message": "历史文章",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "blog.post.empty": {
+    "message": "暂无文章"
+  },
+  "blog.postcard.wordCount": {
+    "message": "{word} 词数"
+  },
+  "blog.postcard.readingTime": {
+    "message": "{readingTime} 分钟"
+  },
+  "blog.postcard.viewCount": {
+    "message": "{viewCount} 浏览"
+  },
+  "blog.sidebar.toc.title": {
+    "message": "目录"
+  },
+  "blog.sidebar.info.location": {
+    "message": "位置"
+  },
+  "blog.sidebar.info.locationValue": {
+    "message": "中国杭州"
+  },
+  "blog.sidebar.info.localTime": {
+    "message": "本地时间"
+  },
+  "blog.sidebar.info.fingerprint": {
+    "message": "GPG 指纹"
+  },
+  "blog.sidebar.info.title": {
+    "message": "信息"
+  },
+  "blog.sidebar.stats.posts": {
+    "message": "文章"
+  },
+  "blog.sidebar.stats.words": {
+    "message": "词数"
+  },
+  "blog.sidebar.stats.visitors": {
+    "message": "访客"
+  },
+  "blog.sidebar.stats.views": {
+    "message": "浏览"
+  },
+  "blog.sidebar.stats.title": {
+    "message": "统计"
+  },
+  "blog.sidebar.tags.title": {
+    "message": "热门标签"
+  },
+  "blog.sidebar.feed.rss": {
+    "message": "RSS 订阅"
+  },
+  "blog.sidebar.feed.atom": {
+    "message": "Atom 订阅"
+  },
+  "blog.sidebar.feed.json": {
+    "message": "JSON 订阅"
+  },
+  "blog.sidebar.feed.title": {
+    "message": "订阅"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "标签",
+    "description": "The title of the tag list page"
+  },
+  "blog.pages.tags.tagSelect": {
+    "message": "标签"
+  },
+  "home.topbanner.title": {
+    "message": "Hello, I'm lailai"
+  },
+  "home.bento.nav.contest": {
+    "message": "竞赛"
+  },
+  "home.bento.nav.note": {
+    "message": "笔记"
+  },
+  "home.bento.nav.project": {
+    "message": "项目"
+  },
+  "home.bento.nav.blog": {
+    "message": "博客"
+  },
+  "home.bento.tag.china": {
+    "message": "中国"
+  },
+  "home.bento.tag.school": {
+    "message": "杭州第二中学"
+  },
+  "home.bento.tag.languages": {
+    "message": "中英双语"
+  },
+  "home.bento.tag.friendly": {
+    "message": "友好"
+  },
+  "home.bento.tag.mbti": {
+    "message": "INTJ"
+  },
+  "home.bento.identity.student": {
+    "message": "学生"
+  },
+  "home.bento.identity.developer": {
+    "message": "开发者"
+  },
+  "home.bento.identity.designer": {
+    "message": "设计师"
+  },
+  "home.bento.identity.oier": {
+    "message": "OIer"
+  },
+  "home.bento.rolePrefix": {
+    "message": "我是一名 "
+  },
+  "home.bento.available": {
+    "message": "可联系"
+  },
+  "home.bento.connect": {
+    "message": "联系"
+  },
+  "home.bento.latestPost": {
+    "message": "最新文章"
+  },
+  "home.bento.noPosts": {
+    "message": "暂无文章。"
+  },
+  "home.blog.empty": {
+    "message": "暂无文章，敬请期待更多内容..."
+  },
+  "home.blog.title": {
+    "message": "学习与实践"
+  },
+  "home.blog.description.p1": {
+    "message": "技术发展日新月异，我们需要保持敏锐的学习能力和好奇心。每一次新技术的掌握，都是对未来的投资。在这里记录学习过程中的思考与总结，分享解决问题的方法和经验。"
+  },
+  "home.blog.description.p2": {
+    "message": "通过不断的实践和总结，将知识转化为真正的技能。只有经过实践验证的技术和方法，才能真正帮助我们解决实际问题。你可以在这里找到算法题解、技术笔记和项目实践等内容。"
+  },
+  "home.blog.more": {
+    "message": "查看更多文章 →"
+  },
+  "home.blog.latest": {
+    "message": "最新文章"
+  },
+  "home.countdown.event": {
+    "message": "2027 年"
+  },
+  "home.countdown.final": {
+    "message": "新年快乐！"
+  },
+  "home.countdown.title": {
+    "message": "倒计时"
+  },
+  "home.countdown.description": {
+    "message": "距离 {event} 还有"
+  },
+  "home.countdown.unit.days": {
+    "message": "天"
+  },
+  "home.countdown.unit.hours": {
+    "message": "时"
+  },
+  "home.countdown.unit.minutes": {
+    "message": "分"
+  },
+  "home.countdown.unit.seconds": {
+    "message": "秒"
+  },
+  "home.fouriertransform.title": {
+    "message": "傅立叶变换"
+  },
+  "home.fouriertransform.description": {
+    "message": "在下方绘制任意形状，观察其傅立叶级数的旋转圆可视化"
+  },
+  "home.lorenz.reset": {
+    "message": "重置"
+  },
+  "home.lorenz.title": {
+    "message": "洛伦兹吸引子"
+  },
+  "home.lorenz.description": {
+    "message": "拖动旋转视角并调整参数，探索确定性混沌与蝴蝶效应"
+  },
+  "home.neuralnetwork.clear": {
+    "message": "清除"
+  },
+  "home.neuralnetwork.check": {
+    "message": "识别数字"
+  },
+  "home.neuralnetwork.preprocess": {
+    "message": "预处理"
+  },
+  "home.neuralnetwork.title": {
+    "message": "神经网络"
+  },
+  "home.neuralnetwork.description": {
+    "message": "在下方绘制数字 0–9，神经网络会识别您的手写数字"
+  },
+  "cookieConsent.title": {
+    "message": "Cookie 设置"
+  },
+  "cookieConsent.description": {
+    "message": "本站使用 Cookie 记录你的偏好，以改善浏览体验。{learnMore}。"
+  },
+  "cookieConsent.learnMore": {
+    "message": "了解更多"
+  },
+  "cookieConsent.reject": {
+    "message": "拒绝"
+  },
+  "cookieConsent.accept": {
+    "message": "接受"
+  },
+  "pages.travel.map.title": {
+    "message": "旅行地图"
+  },
+  "pages.travel.map.description": {
+    "message": "世界那么大，我想去看看。足迹遍布的国家和城市"
+  },
+  "pages.travel.map.legend.visited": {
+    "message": "已到访"
+  },
+  "pages.travel.map.legend.unvisited": {
+    "message": "未到访"
+  },
+  "pages.travel.timeline.title": {
+    "message": "旅行足迹"
+  },
+  "pages.travel.timeline.description": {
+    "message": "纸上得来终觉浅，绝知此事要躬行"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "作者",
+    "description": "The title of the authors page"
+  },
   "theme.ErrorPageContent.title": {
     "message": "页面已崩溃。",
     "description": "The title of the fallback page when the page crashed"
@@ -6,14 +444,6 @@
   "theme.BackToTopButton.buttonAriaLabel": {
     "message": "回到顶部",
     "description": "The ARIA label for the back to top button"
-  },
-  "theme.blog.archive.title": {
-    "message": "历史文章",
-    "description": "The page & hero title of the blog archive page"
-  },
-  "theme.blog.archive.description": {
-    "message": "历史文章",
-    "description": "The page & hero description of the blog archive page"
   },
   "theme.blog.paginator.navAriaLabel": {
     "message": "文章列表分页导航",
@@ -26,6 +456,10 @@
   "theme.blog.paginator.olderEntries": {
     "message": "较旧的文章",
     "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.archive.description": {
+    "message": "历史文章",
+    "description": "The page & hero description of the blog archive page"
   },
   "theme.blog.post.paginator.navAriaLabel": {
     "message": "文章分页导航",
@@ -62,10 +496,6 @@
   "theme.docs.breadcrumbs.navAriaLabel": {
     "message": "页面路径",
     "description": "The ARIA label for the breadcrumbs"
-  },
-  "theme.docs.DocCard.categoryDescription.plurals": {
-    "message": "{count} 个项目",
-    "description": "The default description for a category card in the generated index about how many items this category includes"
   },
   "theme.docs.paginator.navAriaLabel": {
     "message": "文件选项卡",
@@ -138,6 +568,10 @@
     "message": "标签：",
     "description": "The label alongside a tag list"
   },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
   "theme.admonition.caution": {
     "message": "警告",
     "description": "The default label used for the Caution admonition (:::caution)"
@@ -161,10 +595,6 @@
   "theme.admonition.warning": {
     "message": "注意",
     "description": "The default label used for the Warning admonition (:::warning)"
-  },
-  "theme.AnnouncementBar.closeButtonAriaLabel": {
-    "message": "关闭",
-    "description": "The ARIA label for close button of announcement bar"
   },
   "theme.blog.sidebar.navAriaLabel": {
     "message": "最近文章导航",
@@ -202,6 +632,10 @@
     "message": "本页总览",
     "description": "The label used by the button on the collapsible TOC component"
   },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
   "theme.blog.post.readMore": {
     "message": "阅读更多",
     "description": "The label used in blog post item excerpts to link to full blog posts"
@@ -209,10 +643,6 @@
   "theme.blog.post.readMoreLabel": {
     "message": "阅读 {title} 的全文",
     "description": "The ARIA label for the link to full blog posts from excerpts"
-  },
-  "theme.blog.post.readingTime.plurals": {
-    "message": "阅读需 {readingTime} 分钟",
-    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.CodeBlock.copy": {
     "message": "复制",
@@ -277,38 +707,6 @@
   "theme.SearchBar.seeAll": {
     "message": "查看全部 {count} 个结果"
   },
-  "theme.SearchPage.documentsFound.plurals": {
-    "message": "找到 {count} 份文件",
-    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
-  },
-  "theme.SearchPage.existingResultsTitle": {
-    "message": "「{query}」的搜索结果",
-    "description": "The search page title for non-empty query"
-  },
-  "theme.SearchPage.emptyResultsTitle": {
-    "message": "在文档中搜索",
-    "description": "The search page title for empty query"
-  },
-  "theme.SearchPage.inputPlaceholder": {
-    "message": "在此输入搜索字词",
-    "description": "The placeholder for search page input"
-  },
-  "theme.SearchPage.inputLabel": {
-    "message": "搜索",
-    "description": "The ARIA label for search page input"
-  },
-  "theme.SearchPage.algoliaLabel": {
-    "message": "通过 Algolia 搜索",
-    "description": "The description label for Algolia mention"
-  },
-  "theme.SearchPage.noResultsText": {
-    "message": "未找到任何结果",
-    "description": "The paragraph for empty search result"
-  },
-  "theme.SearchPage.fetchingNewResults": {
-    "message": "正在获取新的搜索结果...",
-    "description": "The paragraph for fetching new search results"
-  },
   "theme.SearchBar.label": {
     "message": "搜索",
     "description": "The ARIA label and placeholder for search button"
@@ -320,90 +718,6 @@
   "theme.SearchModal.searchBox.cancelButtonText": {
     "message": "取消",
     "description": "The label and ARIA label for search box cancel button"
-  },
-  "theme.SearchModal.startScreen.recentSearchesTitle": {
-    "message": "最近搜索",
-    "description": "The title for recent searches"
-  },
-  "theme.SearchModal.startScreen.noRecentSearchesText": {
-    "message": "没有最近搜索",
-    "description": "The text when there are no recent searches"
-  },
-  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
-    "message": "保存这个搜索",
-    "description": "The title for save recent search button"
-  },
-  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
-    "message": "从历史记录中删除这个搜索",
-    "description": "The title for remove recent search button"
-  },
-  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
-    "message": "收藏",
-    "description": "The title for favorite searches"
-  },
-  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
-    "message": "从收藏列表中删除这个搜索",
-    "description": "The title for remove favorite search button"
-  },
-  "theme.SearchModal.errorScreen.titleText": {
-    "message": "无法获取结果",
-    "description": "The title for error screen"
-  },
-  "theme.SearchModal.errorScreen.helpText": {
-    "message": "你可能需要检查网络连接。",
-    "description": "The help text for error screen"
-  },
-  "theme.SearchModal.footer.selectText": {
-    "message": "选中",
-    "description": "The select text for footer"
-  },
-  "theme.SearchModal.footer.selectKeyAriaLabel": {
-    "message": "Enter 键",
-    "description": "The ARIA label for select key in footer"
-  },
-  "theme.SearchModal.footer.navigateText": {
-    "message": "导航",
-    "description": "The navigate text for footer"
-  },
-  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
-    "message": "向上键",
-    "description": "The ARIA label for navigate up key in footer"
-  },
-  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
-    "message": "向下键",
-    "description": "The ARIA label for navigate down key in footer"
-  },
-  "theme.SearchModal.footer.closeText": {
-    "message": "关闭",
-    "description": "The close text for footer"
-  },
-  "theme.SearchModal.footer.closeKeyAriaLabel": {
-    "message": "Esc 键",
-    "description": "The ARIA label for close key in footer"
-  },
-  "theme.SearchModal.footer.searchByText": {
-    "message": "搜索提供",
-    "description": "The 'Powered by' text for footer"
-  },
-  "theme.SearchModal.noResultsScreen.noResultsText": {
-    "message": "没有结果：",
-    "description": "The text when there are no results"
-  },
-  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
-    "message": "试试搜索",
-    "description": "The text for suggested query"
-  },
-  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
-    "message": "认为这个查询应该有结果？",
-    "description": "The text for reporting missing results"
-  },
-  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
-    "message": "请告知我们。",
-    "description": "The link text for reporting missing results"
-  },
-  "theme.SearchModal.placeholder": {
-    "message": "搜索文档",
-    "description": "The placeholder of the input of the DocSearch pop-up modal"
   },
   "theme.SearchModal.searchBox.placeholderText": {
     "message": "搜索文档",
@@ -437,6 +751,30 @@
     "message": "返回关键词搜索",
     "description": "The ARIA label for back to keyword search button"
   },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "最近搜索",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "没有最近搜索",
+    "description": "The text when there are no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "保存这个搜索",
+    "description": "The title for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "从历史记录中删除这个搜索",
+    "description": "The title for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "收藏",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "从收藏列表中删除这个搜索",
+    "description": "The title for remove favorite search button"
+  },
   "theme.SearchModal.startScreen.recentConversationsTitle": {
     "message": "最近的对话",
     "description": "The title for recent conversations"
@@ -444,6 +782,14 @@
   "theme.SearchModal.startScreen.removeRecentConversationButtonTitle": {
     "message": "从历史记录中删除此对话",
     "description": "The title for remove recent conversation button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "无法获取结果",
+    "description": "The title for error screen"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "你可能需要检查网络连接。",
+    "description": "The help text for error screen"
   },
   "theme.SearchModal.resultsScreen.askAiPlaceholder": {
     "message": "问 AI: ",
@@ -497,13 +843,97 @@
     "message": "搜索结果",
     "description": "The text after tool call"
   },
+  "theme.SearchModal.footer.selectText": {
+    "message": "选中",
+    "description": "The select text for footer"
+  },
   "theme.SearchModal.footer.submitQuestionText": {
     "message": "提交问题",
     "description": "The submit question text for footer"
   },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter 键",
+    "description": "The ARIA label for select key in footer"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "导航",
+    "description": "The navigate text for footer"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "向上键",
+    "description": "The ARIA label for navigate up key in footer"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "向下键",
+    "description": "The ARIA label for navigate down key in footer"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "关闭",
+    "description": "The close text for footer"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Esc 键",
+    "description": "The ARIA label for close key in footer"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "搜索提供",
+    "description": "The 'Powered by' text for footer"
+  },
   "theme.SearchModal.footer.backToSearchText": {
     "message": "返回搜索",
     "description": "The back to search text for footer"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "没有结果：",
+    "description": "The text when there are no results"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "试试搜索",
+    "description": "The text for suggested query"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "认为这个查询应该有结果？",
+    "description": "The text for reporting missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "请告知我们。",
+    "description": "The link text for reporting missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "搜索文档",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "找到 {count} 份文件",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "「{query}」的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "在文档中搜索",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "在此输入搜索字词",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "搜索",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "通过 Algolia 搜索",
+    "description": "The description label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "未找到任何结果",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "正在获取新的搜索结果...",
+    "description": "The paragraph for fetching new search results"
   },
   "theme.Playground.liveEditor": {
     "message": "实时编辑器",
@@ -529,10 +959,6 @@
     "message": "{authorName} - {nPosts}",
     "description": "The title of the page for a blog author"
   },
-  "theme.blog.authorsList.pageTitle": {
-    "message": "作者",
-    "description": "The title of the authors page"
-  },
   "theme.blog.authorsList.viewAll": {
     "message": "查看所有作者",
     "description": "The label of the link targeting the blog authors page"
@@ -557,6 +983,10 @@
     "message": "此页面是草稿，仅在开发环境中可见，不会包含在正式版本中。",
     "description": "The draft content banner message"
   },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 个项目",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
   "theme.ErrorPageContent.tryAgain": {
     "message": "重试",
     "description": "The label of the button to try again rendering when the React error boundary captures an error"
@@ -564,435 +994,5 @@
   "theme.common.skipToMainContent": {
     "message": "跳到主要内容",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
-  },
-  "theme.tags.tagsPageTitle": {
-    "message": "标签",
-    "description": "The title of the tag list page"
-  },
-  "home.scrollGuide": {
-    "message": "向下滚动"
-  },
-  "home.bento.nav.contest": {
-    "message": "竞赛"
-  },
-  "home.bento.nav.note": {
-    "message": "笔记"
-  },
-  "home.bento.nav.project": {
-    "message": "项目"
-  },
-  "home.bento.nav.blog": {
-    "message": "博客"
-  },
-  "home.bento.tag.china": {
-    "message": "中国"
-  },
-  "home.bento.tag.school": {
-    "message": "杭州第二中学"
-  },
-  "home.bento.tag.languages": {
-    "message": "中英双语"
-  },
-  "home.bento.tag.friendly": {
-    "message": "友好"
-  },
-  "home.bento.tag.mbti": {
-    "message": "INTJ"
-  },
-  "home.bento.identity.student": {
-    "message": "学生"
-  },
-  "home.bento.identity.developer": {
-    "message": "开发者"
-  },
-  "home.bento.identity.designer": {
-    "message": "设计师"
-  },
-  "home.bento.identity.oier": {
-    "message": "OIer"
-  },
-  "home.bento.available": {
-    "message": "可联系"
-  },
-  "home.bento.rolePrefix": {
-    "message": "我是一名 "
-  },
-  "home.bento.connect": {
-    "message": "联系"
-  },
-  "home.bento.latestPost": {
-    "message": "最新文章"
-  },
-  "home.bento.noPosts": {
-    "message": "暂无文章。"
-  },
-  "home.topbanner.title": {
-    "message": "Hello, I'm lailai"
-  },
-  "home.blog.title": {
-    "message": "学习与实践"
-  },
-  "home.blog.description.p1": {
-    "message": "技术发展日新月异，我们需要保持敏锐的学习能力和好奇心。每一次新技术的掌握，都是对未来的投资。在这里记录学习过程中的思考与总结，分享解决问题的方法和经验。"
-  },
-  "home.blog.description.p2": {
-    "message": "通过不断的实践和总结，将知识转化为真正的技能。只有经过实践验证的技术和方法，才能真正帮助我们解决实际问题。你可以在这里找到算法题解、技术笔记和项目实践等内容。"
-  },
-  "home.blog.latest": {
-    "message": "最新文章"
-  },
-  "home.blog.more": {
-    "message": "查看更多文章 →"
-  },
-  "home.blog.empty": {
-    "message": "暂无文章，敬请期待更多内容..."
-  },
-  "home.countdown.title": {
-    "message": "倒计时"
-  },
-  "home.countdown.description": {
-    "message": "距离 {event} 还有"
-  },
-  "home.countdown.event": {
-    "message": "2027 年"
-  },
-  "home.countdown.final": {
-    "message": "新年快乐！"
-  },
-  "home.countdown.unit.days": {
-    "message": "天"
-  },
-  "home.countdown.unit.hours": {
-    "message": "时"
-  },
-  "home.countdown.unit.minutes": {
-    "message": "分"
-  },
-  "home.countdown.unit.seconds": {
-    "message": "秒"
-  },
-  "components.problem.solution": {
-    "message": "题解"
-  },
-  "components.problem.code": {
-    "message": "代码（{num}）"
-  },
-  "components.problem.error": {
-    "message": "无法加载题目「{id}」。"
-  },
-  "components.solution.luogu": {
-    "message": "洛谷"
-  },
-  "components.solution.blog": {
-    "message": "博客"
-  },
-  "components.solution.solution": {
-    "message": "题解"
-  },
-  "home.neuralnetwork.title": {
-    "message": "神经网络"
-  },
-  "home.neuralnetwork.description": {
-    "message": "在下方绘制数字 0–9，神经网络会识别您的手写数字"
-  },
-  "home.neuralnetwork.clear": {
-    "message": "清除"
-  },
-  "home.neuralnetwork.check": {
-    "message": "识别数字"
-  },
-  "home.neuralnetwork.preprocess": {
-    "message": "预处理"
-  },
-  "home.fouriertransform.title": {
-    "message": "傅立叶变换"
-  },
-  "home.fouriertransform.description": {
-    "message": "在下方绘制任意形状，观察其傅立叶级数的旋转圆可视化"
-  },
-  "home.lorenz.title": {
-    "message": "洛伦兹吸引子"
-  },
-  "home.lorenz.description": {
-    "message": "拖动旋转视角并调整参数，探索确定性混沌与蝴蝶效应"
-  },
-  "home.lorenz.reset": {
-    "message": "重置"
-  },
-  "pages.travel.title": {
-    "message": "旅行"
-  },
-  "pages.travel.description": {
-    "message": "每一次旅行都能带来新的视野和感悟"
-  },
-  "pages.travel.modification": {
-    "message": "旅行<b>记录</b>"
-  },
-  "pages.travel.timeline.title": {
-    "message": "旅行足迹"
-  },
-  "pages.travel.timeline.description": {
-    "message": "纸上得来终觉浅，绝知此事要躬行"
-  },
-  "pages.travel.datacard.label1": {
-    "message": "国家/地区"
-  },
-  "pages.travel.datacard.label2": {
-    "message": "年历程"
-  },
-  "pages.travel.map.title": {
-    "message": "旅行地图"
-  },
-  "pages.travel.map.description": {
-    "message": "世界那么大，我想去看看。足迹遍布的国家和城市"
-  },
-  "pages.travel.map.legend.visited": {
-    "message": "已到访"
-  },
-  "pages.travel.map.legend.unvisited": {
-    "message": "未到访"
-  },
-  "pages.friends.title": {
-    "message": "友链"
-  },
-  "pages.friends.description": {
-    "message": "真正的友谊是世上最稀有的东西"
-  },
-  "pages.friends.modification": {
-    "message": "我的<b>友链</b>"
-  },
-  "pages.friends.datacard.label": {
-    "message": "位朋友"
-  },
-  "pages.resources.title": {
-    "message": "资源"
-  },
-  "pages.resources.description": {
-    "message": "精心筛选的优质工具与平台"
-  },
-  "pages.resources.modification": {
-    "message": "精选<b>资源</b>"
-  },
-  "pages.resources.search.placeholder": {
-    "message": "搜索资源"
-  },
-  "pages.resources.category.all": {
-    "message": "全部"
-  },
-  "pages.resources.category.count": {
-    "message": "{count} 项"
-  },
-  "pages.resources.datacard.label1": {
-    "message": "个分类"
-  },
-  "pages.resources.datacard.label2": {
-    "message": "项资源"
-  },
-  "pages.resources.noresults.description": {
-    "message": "找不到和“{query}”相符的资源。"
-  },
-  "pages.resources.noresults.clear": {
-    "message": "清空搜索"
-  },
-  "pages.settings.title": {
-    "message": "设置"
-  },
-  "pages.settings.description": {
-    "message": "自定义网站功能和偏好设置"
-  },
-  "pages.settings.modification": {
-    "message": "个性化<b>设置</b>"
-  },
-  "pages.settings.datacard.label": {
-    "message": "项设置"
-  },
-  "pages.settings.item.theme.title": {
-    "message": "主题"
-  },
-  "pages.settings.item.theme.description": {
-    "message": "切换浅色、深色或跟随系统"
-  },
-  "pages.settings.item.color.title": {
-    "message": "主题色"
-  },
-  "pages.settings.item.color.description": {
-    "message": "自定义网站主色调"
-  },
-  "pages.settings.item.color.reset": {
-    "message": "重置"
-  },
-  "pages.settings.item.font.title": {
-    "message": "排版"
-  },
-  "pages.settings.item.font.description": {
-    "message": "调整文字大小与行间距"
-  },
-  "pages.settings.item.experimental.title": {
-    "message": "实验性功能"
-  },
-  "pages.settings.item.experimental.description": {
-    "message": "试用开发中的新功能"
-  },
-  "pages.settings.item.quickactions.title": {
-    "message": "快捷操作"
-  },
-  "pages.settings.item.quickactions.description": {
-    "message": "一键执行常用操作"
-  },
-  "pages.settings.item.theme.option.system": {
-    "message": "系统模式"
-  },
-  "pages.settings.item.theme.option.light": {
-    "message": "浅色模式"
-  },
-  "pages.settings.item.theme.option.dark": {
-    "message": "深色模式"
-  },
-  "pages.settings.item.font.size.current": {
-    "message": "字体大小：{size}px"
-  },
-  "pages.settings.item.font.lineheight.current": {
-    "message": "行间距：{value}"
-  },
-  "pages.settings.item.experimental.option.originalLayout": {
-    "message": "原版布局"
-  },
-  "pages.settings.item.experimental.option.debugMode": {
-    "message": "调试模式"
-  },
-  "pages.settings.item.experimental.option.grayMode": {
-    "message": "灰色模式"
-  },
-  "pages.settings.item.quickactions.option.confetti": {
-    "message": "给我惊喜"
-  },
-  "pages.settings.item.quickactions.option.reset": {
-    "message": "重置设置"
-  },
-  "blog.postcard.wordCount": {
-    "message": "{word} 词数"
-  },
-  "blog.postcard.readingTime": {
-    "message": "{readingTime} 分钟"
-  },
-  "blog.postcard.viewCount": {
-    "message": "{viewCount} 浏览"
-  },
-  "blog.sidebar.toc.title": {
-    "message": "目录"
-  },
-  "blog.sidebar.feed.title": {
-    "message": "订阅"
-  },
-  "blog.sidebar.feed.rss": {
-    "message": "RSS 订阅"
-  },
-  "blog.sidebar.feed.atom": {
-    "message": "Atom 订阅"
-  },
-  "blog.sidebar.feed.json": {
-    "message": "JSON 订阅"
-  },
-  "blog.sidebar.info.title": {
-    "message": "信息"
-  },
-  "blog.sidebar.info.location": {
-    "message": "位置"
-  },
-  "blog.sidebar.info.locationValue": {
-    "message": "中国杭州"
-  },
-  "blog.sidebar.info.localTime": {
-    "message": "本地时间"
-  },
-  "blog.sidebar.info.fingerprint": {
-    "message": "GPG 指纹"
-  },
-  "blog.sidebar.stats.title": {
-    "message": "统计"
-  },
-  "blog.sidebar.stats.posts": {
-    "message": "文章"
-  },
-  "blog.sidebar.stats.words": {
-    "message": "词数"
-  },
-  "blog.sidebar.stats.visitors": {
-    "message": "访客"
-  },
-  "blog.sidebar.stats.views": {
-    "message": "浏览"
-  },
-  "blog.sidebar.tags.title": {
-    "message": "热门标签"
-  },
-  "blog.post.empty": {
-    "message": "暂无文章"
-  },
-  "blog.pages.tags.tagSelect": {
-    "message": "标签"
-  },
-  "data.changelog.type.added": {
-    "message": "【新增】"
-  },
-  "data.changelog.type.changed": {
-    "message": "【变更】"
-  },
-  "data.changelog.type.deprecated": {
-    "message": "【弃用】"
-  },
-  "data.changelog.type.removed": {
-    "message": "【移除】"
-  },
-  "data.changelog.type.fixed": {
-    "message": "【修复】"
-  },
-  "data.changelog.type.security": {
-    "message": "【安全】"
-  },
-  "cookieConsent.title": {
-    "message": "Cookie 设置"
-  },
-  "cookieConsent.description": {
-    "message": "本站使用 Cookie 记录你的偏好，以改善浏览体验。{learnMore}。"
-  },
-  "cookieConsent.learnMore": {
-    "message": "了解更多"
-  },
-  "cookieConsent.accept": {
-    "message": "接受"
-  },
-  "cookieConsent.reject": {
-    "message": "拒绝"
-  },
-  "data.devices.macbook-pro.spec": {
-    "message": "16 英寸 / 银色 / 14 CPU / 30 GPU / 36GB / 1TB"
-  },
-  "data.devices.ipad-pro.spec": {
-    "message": "11 英寸 / 深空灰色 / 256GB"
-  },
-  "data.devices.iphone.spec": {
-    "message": "星光色 / A15 / 256GB"
-  },
-  "data.devices.apple-watch.spec": {
-    "message": "钛合金 / 石板色 / 46mm / S10"
-  },
-  "data.devices.airpods-pro.spec": {
-    "message": "USB-C / H2 / U1"
-  },
-  "data.devices.airpods-max.spec": {
-    "message": "USB-C / 午夜色 / H1"
-  },
-  "data.devices.powerbeats-pro.spec": {
-    "message": "极速黑 / H2"
-  },
-  "pages.settings.item.color.picker": {
-    "message": "选择颜色"
-  },
-  "pages.settings.item.language.title": {
-    "message": "语言"
-  },
-  "pages.settings.item.language.description": {
-    "message": "切换界面语言"
   }
 }


### PR DESCRIPTION
## Summary
- Reorder keys in `i18n/zh-Hans/code.json` so related entries are grouped together (home, data, components, pages.*, blog, theme.*).
- Values are unchanged — only key order differs.

## Test plan
- [ ] `npm run check` passes locally (requires `npm install` first).
- [ ] Visual diff: confirm no missing/extra keys (file still has 285 keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)