### PR TITLE
Add /insights page: live Umami analytics and Kuma status

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -994,5 +994,95 @@
   "theme.common.skipToMainContent": {
     "message": "跳到主要内容",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "pages.insights.title": {
+    "message": "实时洞察"
+  },
+  "pages.insights.description": {
+    "message": "网站的实时数据，每次访问自动刷新"
+  },
+  "pages.insights.modification": {
+    "message": "实时<b>洞察</b>"
+  },
+  "pages.insights.metric.pageviews": {
+    "message": "浏览量"
+  },
+  "pages.insights.metric.visitors": {
+    "message": "访客数"
+  },
+  "pages.insights.metric.visits": {
+    "message": "访问数"
+  },
+  "pages.insights.metric.avgVisit": {
+    "message": "平均时长"
+  },
+  "pages.insights.metric.bounceRate": {
+    "message": "跳出率"
+  },
+  "pages.insights.range.7d": {
+    "message": "近 7 天"
+  },
+  "pages.insights.range.30d": {
+    "message": "近 30 天"
+  },
+  "pages.insights.range.1y": {
+    "message": "近 1 年"
+  },
+  "pages.insights.chart.title": {
+    "message": "浏览量趋势"
+  },
+  "pages.insights.metricList.pages": {
+    "message": "热门页面"
+  },
+  "pages.insights.metricList.empty": {
+    "message": "暂无数据"
+  },
+  "pages.insights.metricList.referrers": {
+    "message": "来源站点"
+  },
+  "pages.insights.metricList.referrers.direct": {
+    "message": "直接访问"
+  },
+  "pages.insights.metricList.countries": {
+    "message": "访客地区"
+  },
+  "pages.insights.metricList.devices": {
+    "message": "设备类型"
+  },
+  "pages.insights.status.operational": {
+    "message": "全部服务正常"
+  },
+  "pages.insights.status.degraded": {
+    "message": "部分服务异常"
+  },
+  "pages.insights.status.major": {
+    "message": "服务中断"
+  },
+  "pages.insights.status.maintenance": {
+    "message": "维护中"
+  },
+  "pages.insights.status.unknown": {
+    "message": "状态未知"
+  },
+  "pages.insights.uptime.last24h": {
+    "message": "24 小时在线率"
+  },
+  "pages.insights.uptime.checks": {
+    "message": "近 {count} 次检测"
+  },
+  "pages.insights.uptime.avgPing": {
+    "message": "平均 {ping}ms"
+  },
+  "pages.insights.uptime.title": {
+    "message": "服务状态"
+  },
+  "pages.insights.status.loading": {
+    "message": "检测中…"
+  },
+  "pages.insights.status.error": {
+    "message": "无法连接监控服务"
+  },
+  "pages.insights.uptime.empty": {
+    "message": "暂无监控项"
   }
 }

--- a/src/data/changelog.tsx
+++ b/src/data/changelog.tsx
@@ -9,6 +9,12 @@ interface ChangelogItem {
 export const CHANGELOG_LIST: ChangelogItem[] = [
   {
     date: '2026-05-01',
+    type: 'added',
+    content:
+      '<a href="/insights"><b>实时洞察</b></a> 页面，整合 Umami 访问统计与 Uptime Kuma 服务状态',
+  },
+  {
+    date: '2026-05-01',
     type: 'changed',
     content:
       '网站更新至 <a href="https://docusaurus.io/changelog/3.10.1">Docusaurus v3.10.1</a>',

--- a/src/hooks/useAnimatedNumber.ts
+++ b/src/hooks/useAnimatedNumber.ts
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from 'react';
+
+const DEFAULT_DURATION_MS = 900;
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+export function useAnimatedNumber(
+  target: number | null | undefined,
+  durationMs: number = DEFAULT_DURATION_MS
+): number {
+  const [value, setValue] = useState<number>(target ?? 0);
+  const fromRef = useRef<number>(target ?? 0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (target == null || !Number.isFinite(target)) return;
+
+    if (typeof window === 'undefined') {
+      setValue(target);
+      return;
+    }
+
+    const from = fromRef.current;
+    const delta = target - from;
+    if (delta === 0) {
+      setValue(target);
+      return;
+    }
+
+    const start = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / durationMs);
+      const eased = easeOutCubic(t);
+      const next = from + delta * eased;
+      setValue(next);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        fromRef.current = target;
+        rafRef.current = null;
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+      fromRef.current = value;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [target, durationMs]);
+
+  return value;
+}

--- a/src/hooks/useKumaStatus.ts
+++ b/src/hooks/useKumaStatus.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import {
+  getStatusPage,
+  getHeartbeats,
+  type KumaStatusPageData,
+  type KumaHeartbeatData,
+} from '@site/src/utils/kuma';
+import type { FetchStatus } from './useUmamiStats';
+
+export interface KumaCombined {
+  page: KumaStatusPageData;
+  heartbeats: KumaHeartbeatData;
+}
+
+export function useKumaStatus() {
+  const [data, setData] = useState<KumaCombined | null>(null);
+  const [status, setStatus] = useState<FetchStatus>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      setStatus('loading');
+      try {
+        const [page, heartbeats] = await Promise.all([
+          getStatusPage(),
+          getHeartbeats(),
+        ]);
+        if (cancelled) return;
+        setData({ page, heartbeats });
+        setStatus('success');
+      } catch (error) {
+        if (cancelled) return;
+        console.error(error);
+        setStatus('error');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, status };
+}

--- a/src/hooks/useUmamiMetric.ts
+++ b/src/hooks/useUmamiMetric.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { umamiFetchJson } from '@site/src/utils/umami';
+import type { InsightsRange, FetchStatus } from './useUmamiStats';
+
+export type MetricType = 'path' | 'referrer' | 'country' | 'device' | 'browser';
+
+export interface MetricItem {
+  x: string;
+  y: number;
+}
+
+export function useUmamiMetric(
+  type: MetricType,
+  range: InsightsRange,
+  limit: number = 8
+) {
+  const [items, setItems] = useState<MetricItem[]>([]);
+  const [status, setStatus] = useState<FetchStatus>('loading');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const endAt = Date.now();
+    const startAt = endAt - range * 24 * 60 * 60 * 1000;
+
+    (async () => {
+      setStatus('loading');
+      try {
+        const result = await umamiFetchJson<MetricItem[]>(
+          '/api/websites/{id}/metrics',
+          { startAt, endAt, type, limit },
+          { signal: controller.signal }
+        );
+        if (controller.signal.aborted) return;
+        setItems(Array.isArray(result) ? result : []);
+        setStatus('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error(error);
+        setStatus('error');
+      }
+    })();
+
+    return () => controller.abort();
+  }, [type, range, limit]);
+
+  return { items, status };
+}

--- a/src/hooks/useUmamiPageviewsSeries.ts
+++ b/src/hooks/useUmamiPageviewsSeries.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react';
+import { umamiFetchJson } from '@site/src/utils/umami';
+import type { InsightsRange, FetchStatus } from './useUmamiStats';
+
+export type SeriesUnit = 'day' | 'hour' | 'month';
+
+export interface SeriesPoint {
+  x: string;
+  y: number;
+}
+
+interface PageviewsResponse {
+  pageviews: SeriesPoint[];
+  sessions: SeriesPoint[];
+}
+
+export function useUmamiPageviewsSeries(range: InsightsRange) {
+  const [data, setData] = useState<PageviewsResponse | null>(null);
+  const [status, setStatus] = useState<FetchStatus>('loading');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const endAt = Date.now();
+    const startAt = endAt - range * 24 * 60 * 60 * 1000;
+    const unit: SeriesUnit = 'day';
+    const timezone =
+      typeof Intl !== 'undefined'
+        ? Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
+        : 'UTC';
+
+    (async () => {
+      setStatus('loading');
+      try {
+        const result = await umamiFetchJson<PageviewsResponse>(
+          '/api/websites/{id}/pageviews',
+          { startAt, endAt, unit, timezone },
+          { signal: controller.signal }
+        );
+        if (controller.signal.aborted) return;
+        setData(result);
+        setStatus('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error(error);
+        setStatus('error');
+      }
+    })();
+
+    return () => controller.abort();
+  }, [range]);
+
+  return { data, status };
+}

--- a/src/hooks/useUmamiStats.ts
+++ b/src/hooks/useUmamiStats.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { umamiFetchJson } from '@site/src/utils/umami';
+
+export type InsightsRange = 7 | 30 | 365;
+
+export interface UmamiStats {
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+}
+
+export type FetchStatus = 'loading' | 'success' | 'error';
+
+interface UmamiStatsResponse extends UmamiStats {
+  comparison?: UmamiStats;
+}
+
+export function useUmamiStats(range: InsightsRange) {
+  const [data, setData] = useState<UmamiStatsResponse | null>(null);
+  const [status, setStatus] = useState<FetchStatus>('loading');
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const endAt = Date.now();
+    const startAt = endAt - range * 24 * 60 * 60 * 1000;
+
+    (async () => {
+      setStatus('loading');
+      try {
+        const result = await umamiFetchJson<UmamiStatsResponse>(
+          '/api/websites/{id}/stats',
+          { startAt, endAt },
+          { signal: controller.signal }
+        );
+        if (controller.signal.aborted) return;
+        setData(result);
+        setStatus('success');
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        console.error(error);
+        setStatus('error');
+      }
+    })();
+
+    return () => controller.abort();
+  }, [range]);
+
+  return { data, status };
+}

--- a/src/pages/insights/_components/HeartbeatBar.module.css
+++ b/src/pages/insights/_components/HeartbeatBar.module.css
@@ -1,0 +1,57 @@
+.bar {
+  display: flex;
+  gap: 2px;
+  height: 28px;
+  width: 100%;
+}
+
+.cell {
+  flex: 1;
+  min-width: 3px;
+  border-radius: 3px;
+  transition:
+    transform 160ms ease,
+    opacity 160ms ease;
+  cursor: help;
+}
+
+.cell:hover {
+  transform: scaleY(1.15);
+}
+
+.up {
+  background: #1a8754;
+}
+
+.down {
+  background: #d93838;
+}
+
+.pending {
+  background: #f0a52a;
+}
+
+.maintenance {
+  background: #5a8dee;
+}
+
+.empty {
+  background: var(--ifm-color-emphasis-200);
+  cursor: default;
+}
+
+html[data-theme='dark'] .up {
+  background: #34c77b;
+}
+
+html[data-theme='dark'] .down {
+  background: #ff6b6b;
+}
+
+html[data-theme='dark'] .pending {
+  background: #ffb84a;
+}
+
+html[data-theme='dark'] .maintenance {
+  background: #7aa6ff;
+}

--- a/src/pages/insights/_components/HeartbeatBar.tsx
+++ b/src/pages/insights/_components/HeartbeatBar.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import type { KumaHeartbeat } from '@site/src/utils/kuma';
+import styles from './HeartbeatBar.module.css';
+
+interface HeartbeatBarProps {
+  beats: KumaHeartbeat[];
+  slots?: number;
+}
+
+function statusClass(status: number | undefined): string {
+  switch (status) {
+    case 1:
+      return styles.up;
+    case 0:
+      return styles.down;
+    case 2:
+      return styles.pending;
+    case 3:
+      return styles.maintenance;
+    default:
+      return styles.empty;
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+export default function HeartbeatBar({ beats, slots = 60 }: HeartbeatBarProps) {
+  const padded: (KumaHeartbeat | null)[] = [];
+  const start = Math.max(0, beats.length - slots);
+  const recent = beats.slice(start);
+  const empty = slots - recent.length;
+  for (let i = 0; i < empty; i++) padded.push(null);
+  for (const b of recent) padded.push(b);
+
+  return (
+    <div className={styles.bar} role="img" aria-label="Recent heartbeat status">
+      {padded.map((beat, i) => {
+        if (!beat) {
+          return <span key={i} className={`${styles.cell} ${styles.empty}`} />;
+        }
+        const tooltip =
+          `${formatTime(beat.time)}` +
+          (typeof beat.ping === 'number' ? ` · ${beat.ping}ms` : '') +
+          (beat.msg ? ` · ${beat.msg}` : '');
+        return (
+          <span
+            key={i}
+            className={`${styles.cell} ${statusClass(beat.status)}`}
+            title={tooltip}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/insights/_components/MetricList.module.css
+++ b/src/pages/insights/_components/MetricList.module.css
@@ -1,0 +1,137 @@
+.card {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 18px;
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 320px;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.card:hover {
+  border-color: var(--ifm-color-emphasis-300);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.06);
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0 0.25rem;
+}
+
+.icon {
+  font-size: 1.1rem;
+  color: var(--ifm-color-primary);
+}
+
+.title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0;
+  color: var(--ifm-font-color-base);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  font-size: 0.92rem;
+  transition: background 160ms ease;
+}
+
+.row:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.bar {
+  position: absolute;
+  inset: 4px auto 4px 0;
+  background: rgba(var(--ifm-color-primary-rgb), 0.08);
+  border-radius: 8px;
+  pointer-events: none;
+  transition: width 600ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.label {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--ifm-color-emphasis-900);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.value {
+  position: relative;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-700);
+  margin-left: 0.75rem;
+}
+
+.empty {
+  margin: 0;
+  padding: 1.5rem 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.skeletonList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.skeletonRow {
+  height: 32px;
+  border-radius: 10px;
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-emphasis-100) 0%,
+    var(--ifm-color-emphasis-200) 50%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.flag {
+  font-size: 1.05rem;
+  flex-shrink: 0;
+}

--- a/src/pages/insights/_components/MetricList.tsx
+++ b/src/pages/insights/_components/MetricList.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Icon } from '@iconify/react';
+import styles from './MetricList.module.css';
+
+export interface MetricRow {
+  x: string;
+  y: number;
+}
+
+interface MetricListProps {
+  title: string;
+  icon: string;
+  items: MetricRow[];
+  loading?: boolean;
+  emptyText: string;
+  renderLabel?: (x: string) => React.ReactNode;
+  formatValue?: (y: number) => string;
+}
+
+function defaultFormat(n: number): string {
+  return new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(n);
+}
+
+export default function MetricList({
+  title,
+  icon,
+  items,
+  loading,
+  emptyText,
+  renderLabel,
+  formatValue = defaultFormat,
+}: MetricListProps) {
+  const max = items.length > 0 ? Math.max(...items.map((i) => i.y), 1) : 1;
+
+  return (
+    <section className={styles.card}>
+      <header className={styles.head}>
+        <Icon icon={icon} className={styles.icon} />
+        <h3 className={styles.title}>{title}</h3>
+      </header>
+      <div className={styles.body}>
+        {loading ? (
+          <div className={styles.skeletonList}>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className={styles.skeletonRow} />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <p className={styles.empty}>{emptyText}</p>
+        ) : (
+          <ol className={styles.list}>
+            {items.map((item, i) => {
+              const ratio = item.y / max;
+              return (
+                <li key={`${item.x}-${i}`} className={styles.row}>
+                  <div
+                    className={styles.bar}
+                    style={{ width: `${ratio * 100}%` }}
+                  />
+                  <span className={styles.label}>
+                    {renderLabel ? renderLabel(item.x) : item.x}
+                  </span>
+                  <span className={styles.value}>{formatValue(item.y)}</span>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/insights/_components/Sparkline.module.css
+++ b/src/pages/insights/_components/Sparkline.module.css
@@ -1,0 +1,65 @@
+.sparkline {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 14px;
+}
+
+.svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.line {
+  stroke-dasharray: 3000;
+  stroke-dashoffset: 3000;
+  animation: draw 1100ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
+}
+
+@keyframes draw {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.pulse {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation: pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.18;
+  }
+  50% {
+    transform: scale(1.6);
+    opacity: 0;
+  }
+}
+
+.skeleton {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-emphasis-100) 0%,
+    var(--ifm-color-emphasis-200) 50%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  background-size: 200% 100%;
+  border-radius: 14px;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/src/pages/insights/_components/Sparkline.tsx
+++ b/src/pages/insights/_components/Sparkline.tsx
@@ -1,0 +1,143 @@
+import React, { useId, useMemo } from 'react';
+import type { SeriesPoint } from '@site/src/hooks/useUmamiPageviewsSeries';
+import styles from './Sparkline.module.css';
+
+interface SparklineProps {
+  data: SeriesPoint[];
+  height?: number;
+  loading?: boolean;
+}
+
+function buildPath(
+  values: number[],
+  width: number,
+  height: number,
+  padding: number
+): { line: string; area: string } {
+  if (values.length === 0) {
+    return { line: '', area: '' };
+  }
+
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const span = max - min || 1;
+  const innerW = width - padding * 2;
+  const innerH = height - padding * 2;
+  const stepX = values.length > 1 ? innerW / (values.length - 1) : 0;
+
+  const xs = values.map((_, i) => padding + i * stepX);
+  const ys = values.map((v) => padding + innerH - ((v - min) / span) * innerH);
+
+  let line = `M ${xs[0].toFixed(2)} ${ys[0].toFixed(2)}`;
+  for (let i = 1; i < values.length; i++) {
+    const cpx = (xs[i - 1] + xs[i]) / 2;
+    line += ` C ${cpx.toFixed(2)} ${ys[i - 1].toFixed(2)}, ${cpx.toFixed(2)} ${ys[i].toFixed(2)}, ${xs[i].toFixed(2)} ${ys[i].toFixed(2)}`;
+  }
+
+  const baseY = height - padding;
+  const area = `${line} L ${xs[xs.length - 1].toFixed(2)} ${baseY.toFixed(2)} L ${xs[0].toFixed(2)} ${baseY.toFixed(2)} Z`;
+
+  return { line, area };
+}
+
+export default function Sparkline({
+  data,
+  height = 220,
+  loading = false,
+}: SparklineProps) {
+  const gradientId = useId();
+  const width = 1200;
+  const padding = 8;
+
+  const values = useMemo(() => data.map((d) => d.y), [data]);
+  const { line, area } = useMemo(
+    () => buildPath(values, width, height, padding),
+    [values, width, height, padding]
+  );
+
+  const lastIndex = values.length - 1;
+  const lastDot =
+    values.length > 0
+      ? {
+          x:
+            padding +
+            (values.length > 1
+              ? (lastIndex * (width - padding * 2)) / (values.length - 1)
+              : (width - padding * 2) / 2),
+          y: (() => {
+            const max = Math.max(...values, 1);
+            const min = Math.min(...values, 0);
+            const span = max - min || 1;
+            const innerH = height - padding * 2;
+            return (
+              padding + innerH - ((values[lastIndex] - min) / span) * innerH
+            );
+          })(),
+        }
+      : null;
+
+  if (loading || values.length === 0) {
+    return (
+      <div className={styles.sparkline} style={{ height }}>
+        <div className={styles.skeleton} />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.sparkline} style={{ height }}>
+      <svg
+        className={styles.svg}
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop
+              offset="0%"
+              stopColor="var(--ifm-color-primary)"
+              stopOpacity="0.32"
+            />
+            <stop
+              offset="100%"
+              stopColor="var(--ifm-color-primary)"
+              stopOpacity="0"
+            />
+          </linearGradient>
+        </defs>
+        <path d={area} fill={`url(#${gradientId})`} />
+        <path
+          d={line}
+          fill="none"
+          stroke="var(--ifm-color-primary)"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          className={styles.line}
+        />
+        {lastDot && (
+          <>
+            <circle
+              cx={lastDot.x}
+              cy={lastDot.y}
+              r="9"
+              fill="var(--ifm-color-primary)"
+              opacity="0.18"
+              className={styles.pulse}
+            />
+            <circle
+              cx={lastDot.x}
+              cy={lastDot.y}
+              r="4"
+              fill="var(--ifm-color-primary)"
+              stroke="var(--ifm-card-background-color)"
+              strokeWidth="2"
+            />
+          </>
+        )}
+      </svg>
+    </div>
+  );
+}

--- a/src/pages/insights/_components/UptimeSection.module.css
+++ b/src/pages/insights/_components/UptimeSection.module.css
@@ -1,0 +1,221 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--ifm-font-color-base);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.pillUp {
+  background: rgba(26, 135, 84, 0.1);
+  color: #1a8754;
+  border-color: rgba(26, 135, 84, 0.25);
+}
+
+.pillDown {
+  background: rgba(217, 56, 56, 0.1);
+  color: #d93838;
+  border-color: rgba(217, 56, 56, 0.25);
+}
+
+.pillMaintenance {
+  background: rgba(90, 141, 238, 0.1);
+  color: #5a8dee;
+  border-color: rgba(90, 141, 238, 0.25);
+}
+
+.pillEmpty {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  border-color: var(--ifm-color-emphasis-200);
+}
+
+html[data-theme='dark'] .pillUp {
+  background: rgba(52, 199, 123, 0.16);
+  color: #34c77b;
+  border-color: rgba(52, 199, 123, 0.32);
+}
+
+html[data-theme='dark'] .pillDown {
+  background: rgba(255, 107, 107, 0.16);
+  color: #ff6b6b;
+  border-color: rgba(255, 107, 107, 0.32);
+}
+
+html[data-theme='dark'] .pillMaintenance {
+  background: rgba(122, 166, 255, 0.16);
+  color: #7aa6ff;
+  border-color: rgba(122, 166, 255, 0.32);
+}
+
+.spin {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.row {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 16px;
+  padding: 1.1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.row:hover {
+  border-color: var(--ifm-color-emphasis-300);
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.05);
+}
+
+.rowHead {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
+}
+
+.dotUp {
+  background: #1a8754;
+  box-shadow: 0 0 0 4px rgba(26, 135, 84, 0.18);
+}
+
+.dotDown {
+  background: #d93838;
+  box-shadow: 0 0 0 4px rgba(217, 56, 56, 0.2);
+}
+
+.dotPending {
+  background: #f0a52a;
+  box-shadow: 0 0 0 4px rgba(240, 165, 42, 0.2);
+}
+
+.dotMaintenance {
+  background: #5a8dee;
+  box-shadow: 0 0 0 4px rgba(90, 141, 238, 0.2);
+}
+
+.dotEmpty {
+  background: var(--ifm-color-emphasis-300);
+}
+
+html[data-theme='dark'] .dotUp {
+  background: #34c77b;
+  box-shadow: 0 0 0 4px rgba(52, 199, 123, 0.22);
+}
+
+html[data-theme='dark'] .dotDown {
+  background: #ff6b6b;
+  box-shadow: 0 0 0 4px rgba(255, 107, 107, 0.22);
+}
+
+.name {
+  flex: 1;
+  font-weight: 600;
+  color: var(--ifm-color-emphasis-900);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.uptime {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.uptimeValue {
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--ifm-font-color-base);
+}
+
+.uptimeLabel {
+  font-size: 0.75rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.rowFoot {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+  font-variant-numeric: tabular-nums;
+}
+
+.skeletonRow {
+  height: 96px;
+  border-radius: 16px;
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-emphasis-100) 0%,
+    var(--ifm-color-emphasis-200) 50%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.empty {
+  margin: 0;
+  padding: 1.5rem 0.75rem;
+  color: var(--ifm-color-emphasis-500);
+  text-align: center;
+  font-size: 0.9rem;
+}

--- a/src/pages/insights/_components/UptimeSection.tsx
+++ b/src/pages/insights/_components/UptimeSection.tsx
@@ -1,0 +1,254 @@
+import React from 'react';
+import { Icon } from '@iconify/react';
+import { translate } from '@docusaurus/Translate';
+import { useKumaStatus } from '@site/src/hooks/useKumaStatus';
+import type { KumaHeartbeat, KumaMonitor } from '@site/src/utils/kuma';
+import HeartbeatBar from './HeartbeatBar';
+import styles from './UptimeSection.module.css';
+
+type OverallStatus =
+  | 'operational'
+  | 'degraded'
+  | 'major'
+  | 'maintenance'
+  | 'unknown';
+
+function lastStatus(beats: KumaHeartbeat[] | undefined): number | undefined {
+  if (!beats || beats.length === 0) return undefined;
+  return beats[beats.length - 1].status;
+}
+
+function avgPing(beats: KumaHeartbeat[] | undefined): number | null {
+  if (!beats || beats.length === 0) return null;
+  const valid = beats.filter(
+    (b) => typeof b.ping === 'number' && Number.isFinite(b.ping)
+  );
+  if (valid.length === 0) return null;
+  return Math.round(
+    valid.reduce((s, b) => s + (b.ping ?? 0), 0) / valid.length
+  );
+}
+
+function overall(
+  monitors: KumaMonitor[],
+  beats: Record<string, KumaHeartbeat[]>
+): OverallStatus {
+  if (monitors.length === 0) return 'unknown';
+  let down = 0;
+  let pending = 0;
+  let maintenance = 0;
+  let up = 0;
+  for (const m of monitors) {
+    const s = lastStatus(beats[String(m.id)]);
+    if (s === 1) up++;
+    else if (s === 0) down++;
+    else if (s === 2) pending++;
+    else if (s === 3) maintenance++;
+  }
+  if (down >= monitors.length) return 'major';
+  if (down > 0) return 'degraded';
+  if (maintenance > 0) return 'maintenance';
+  if (up > 0) return 'operational';
+  if (pending > 0) return 'unknown';
+  return 'unknown';
+}
+
+const STATUS_COPY: Record<
+  OverallStatus,
+  { label: string; icon: string; cls: string }
+> = {
+  operational: {
+    label: translate({
+      id: 'pages.insights.status.operational',
+      message: 'All systems operational',
+    }),
+    icon: 'lucide:check-circle-2',
+    cls: 'pillUp',
+  },
+  degraded: {
+    label: translate({
+      id: 'pages.insights.status.degraded',
+      message: 'Partial outage',
+    }),
+    icon: 'lucide:alert-triangle',
+    cls: 'pillDown',
+  },
+  major: {
+    label: translate({
+      id: 'pages.insights.status.major',
+      message: 'Major outage',
+    }),
+    icon: 'lucide:x-circle',
+    cls: 'pillDown',
+  },
+  maintenance: {
+    label: translate({
+      id: 'pages.insights.status.maintenance',
+      message: 'Under maintenance',
+    }),
+    icon: 'lucide:wrench',
+    cls: 'pillMaintenance',
+  },
+  unknown: {
+    label: translate({
+      id: 'pages.insights.status.unknown',
+      message: 'Status unknown',
+    }),
+    icon: 'lucide:help-circle',
+    cls: 'pillEmpty',
+  },
+};
+
+function MonitorRow({
+  monitor,
+  beats,
+  uptime24,
+}: {
+  monitor: KumaMonitor;
+  beats: KumaHeartbeat[] | undefined;
+  uptime24: number | undefined;
+}) {
+  const last = lastStatus(beats);
+  const ping = avgPing(beats);
+  const upPct =
+    typeof uptime24 === 'number' ? (uptime24 * 100).toFixed(2) : '–';
+
+  const statusCls =
+    last === 1
+      ? styles.dotUp
+      : last === 0
+        ? styles.dotDown
+        : last === 2
+          ? styles.dotPending
+          : last === 3
+            ? styles.dotMaintenance
+            : styles.dotEmpty;
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.rowHead}>
+        <span className={`${styles.dot} ${statusCls}`} aria-hidden="true" />
+        <span className={styles.name}>{monitor.name}</span>
+        <span className={styles.uptime}>
+          <span className={styles.uptimeValue}>{upPct}%</span>
+          <span className={styles.uptimeLabel}>
+            {translate({
+              id: 'pages.insights.uptime.last24h',
+              message: '24h uptime',
+            })}
+          </span>
+        </span>
+      </div>
+      <HeartbeatBar beats={beats ?? []} slots={60} />
+      <div className={styles.rowFoot}>
+        <span>
+          {translate(
+            {
+              id: 'pages.insights.uptime.checks',
+              message: '{count} recent checks',
+            },
+            { count: beats?.length ?? 0 }
+          )}
+        </span>
+        {ping != null && (
+          <span>
+            {translate(
+              {
+                id: 'pages.insights.uptime.avgPing',
+                message: 'Avg {ping}ms',
+              },
+              { ping }
+            )}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function UptimeSection() {
+  const { data, status } = useKumaStatus();
+  const loading = status === 'loading';
+  const errored = status === 'error';
+
+  const monitors: KumaMonitor[] = data
+    ? data.page.publicGroupList.flatMap((g) => g.monitorList)
+    : [];
+  const heartbeats = data?.heartbeats.heartbeatList ?? {};
+  const uptimes = data?.heartbeats.uptimeList ?? {};
+
+  const ovStatus = overall(monitors, heartbeats);
+  const ovCopy = STATUS_COPY[ovStatus];
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.head}>
+        <h2 className={styles.title}>
+          {translate({
+            id: 'pages.insights.uptime.title',
+            message: 'System status',
+          })}
+        </h2>
+        <span
+          className={`${styles.pill} ${
+            loading
+              ? styles.pillEmpty
+              : errored
+                ? styles.pillDown
+                : (styles as Record<string, string>)[ovCopy.cls]
+          }`}
+        >
+          <Icon
+            icon={
+              loading
+                ? 'lucide:loader-2'
+                : errored
+                  ? 'lucide:cloud-off'
+                  : ovCopy.icon
+            }
+            className={loading ? styles.spin : undefined}
+          />
+          <span>
+            {loading
+              ? translate({
+                  id: 'pages.insights.status.loading',
+                  message: 'Checking…',
+                })
+              : errored
+                ? translate({
+                    id: 'pages.insights.status.error',
+                    message: 'Unable to reach status server',
+                  })
+                : ovCopy.label}
+          </span>
+        </span>
+      </header>
+
+      {!errored && (
+        <div className={styles.list}>
+          {loading ? (
+            Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className={styles.skeletonRow} />
+            ))
+          ) : monitors.length === 0 ? (
+            <p className={styles.empty}>
+              {translate({
+                id: 'pages.insights.uptime.empty',
+                message: 'No monitors published.',
+              })}
+            </p>
+          ) : (
+            monitors.map((m) => (
+              <MonitorRow
+                key={m.id}
+                monitor={m}
+                beats={heartbeats[String(m.id)]}
+                uptime24={uptimes[`${m.id}_24`]}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -1,0 +1,415 @@
+import React, { type ReactNode, useEffect, useState } from 'react';
+import clsx from 'clsx';
+import Layout from '@theme/Layout';
+import { translate } from '@docusaurus/Translate';
+import * as countries from 'i18n-iso-countries';
+import countriesEn from 'i18n-iso-countries/langs/en.json';
+import countriesZh from 'i18n-iso-countries/langs/zh.json';
+import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  useUmamiStats,
+  type InsightsRange,
+  type UmamiStats,
+} from '@site/src/hooks/useUmamiStats';
+import { useUmamiPageviewsSeries } from '@site/src/hooks/useUmamiPageviewsSeries';
+import { useUmamiMetric } from '@site/src/hooks/useUmamiMetric';
+import { useAnimatedNumber } from '@site/src/hooks/useAnimatedNumber';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Sparkline from './_components/Sparkline';
+import MetricList from './_components/MetricList';
+import metricListStyles from './_components/MetricList.module.css';
+import UptimeSection from './_components/UptimeSection';
+import styles from './styles.module.css';
+
+countries.registerLocale(countriesEn);
+countries.registerLocale(countriesZh);
+
+const TITLE = translate({
+  id: 'pages.insights.title',
+  message: 'Insights',
+});
+const DESCRIPTION = translate({
+  id: 'pages.insights.description',
+  message: 'Live numbers from this site, refreshed each visit.',
+});
+const MODIFICATION = translate({
+  id: 'pages.insights.modification',
+  message: 'Live <b>Insights</b>',
+});
+
+function formatCompact(n: number): string {
+  if (!Number.isFinite(n)) return '–';
+  return new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(Math.round(n));
+}
+
+function formatDuration(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds <= 0) return '0s';
+  const s = Math.round(seconds);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  if (m < 60) return rem === 0 ? `${m}m` : `${m}m ${rem}s`;
+  const h = Math.floor(m / 60);
+  const remM = m % 60;
+  return remM === 0 ? `${h}h` : `${h}h ${remM}m`;
+}
+
+function formatPercent(n: number): string {
+  if (!Number.isFinite(n)) return '–';
+  return `${(n * 100).toFixed(1)}%`;
+}
+
+function deltaPercent(curr: number, prev: number): number | null {
+  if (!Number.isFinite(curr) || !Number.isFinite(prev) || prev === 0)
+    return null;
+  return (curr - prev) / prev;
+}
+
+interface MetricSpec {
+  key: keyof UmamiStats | 'bounceRate' | 'avgVisit';
+  label: string;
+  format: (n: number) => string;
+  invertDelta?: boolean;
+}
+
+function deriveMetric(
+  spec: MetricSpec,
+  data: UmamiStats | null | undefined
+): number {
+  if (!data) return 0;
+  switch (spec.key) {
+    case 'bounceRate':
+      return data.visits > 0 ? data.bounces / data.visits : 0;
+    case 'avgVisit':
+      return data.visits > 0 ? data.totaltime / data.visits : 0;
+    default:
+      return data[spec.key as keyof UmamiStats] ?? 0;
+  }
+}
+
+function HeroMetric({
+  spec,
+  current,
+  previous,
+  loading,
+}: {
+  spec: MetricSpec;
+  current: number;
+  previous: number;
+  loading: boolean;
+}) {
+  const animated = useAnimatedNumber(loading ? null : current);
+  const delta = deltaPercent(current, previous);
+  const sign =
+    delta == null
+      ? null
+      : Math.abs(delta) < 0.001
+        ? 'flat'
+        : delta > 0
+          ? 'up'
+          : 'down';
+  const positive =
+    sign === 'flat' ? null : spec.invertDelta ? sign === 'down' : sign === 'up';
+
+  return (
+    <div className={styles.heroTile}>
+      <span className={styles.heroLabel}>{spec.label}</span>
+      <span
+        className={
+          loading
+            ? `${styles.heroValue} ${styles.skeletonText}`
+            : styles.heroValue
+        }
+      >
+        {loading ? '0' : spec.format(animated)}
+      </span>
+      {!loading && delta != null && sign !== 'flat' && (
+        <span className={positive ? styles.heroDeltaUp : styles.heroDeltaDown}>
+          {sign === 'up' ? '↑' : '↓'} {Math.abs(delta * 100).toFixed(1)}%
+        </span>
+      )}
+      {!loading && (delta == null || sign === 'flat') && (
+        <span className={styles.heroDeltaFlat}>—</span>
+      )}
+    </div>
+  );
+}
+
+function HeroGrid({ range }: { range: InsightsRange }) {
+  const { data, status } = useUmamiStats(range);
+  const loading = status === 'loading';
+  const errored = status === 'error';
+
+  const specs: MetricSpec[] = [
+    {
+      key: 'pageviews',
+      label: translate({
+        id: 'pages.insights.metric.pageviews',
+        message: 'Pageviews',
+      }),
+      format: formatCompact,
+    },
+    {
+      key: 'visitors',
+      label: translate({
+        id: 'pages.insights.metric.visitors',
+        message: 'Visitors',
+      }),
+      format: formatCompact,
+    },
+    {
+      key: 'visits',
+      label: translate({
+        id: 'pages.insights.metric.visits',
+        message: 'Visits',
+      }),
+      format: formatCompact,
+    },
+    {
+      key: 'avgVisit',
+      label: translate({
+        id: 'pages.insights.metric.avgVisit',
+        message: 'Avg. Visit',
+      }),
+      format: formatDuration,
+    },
+    {
+      key: 'bounceRate',
+      label: translate({
+        id: 'pages.insights.metric.bounceRate',
+        message: 'Bounce Rate',
+      }),
+      format: formatPercent,
+      invertDelta: true,
+    },
+  ];
+
+  return (
+    <div className={styles.heroGrid}>
+      {specs.map((spec) => {
+        const current = deriveMetric(spec, data);
+        const previous = deriveMetric(spec, data?.comparison ?? null);
+        return (
+          <HeroMetric
+            key={spec.key}
+            spec={spec}
+            current={current}
+            previous={previous}
+            loading={loading || errored}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function RangeBar({
+  range,
+  onChange,
+}: {
+  range: InsightsRange;
+  onChange: (r: InsightsRange) => void;
+}) {
+  const items: { value: InsightsRange; label: string }[] = [
+    {
+      value: 7,
+      label: translate({
+        id: 'pages.insights.range.7d',
+        message: '7 days',
+      }),
+    },
+    {
+      value: 30,
+      label: translate({
+        id: 'pages.insights.range.30d',
+        message: '30 days',
+      }),
+    },
+    {
+      value: 365,
+      label: translate({
+        id: 'pages.insights.range.1y',
+        message: '1 year',
+      }),
+    },
+  ];
+  return (
+    <div className={styles.rangeBar}>
+      <div className={styles.rangeTabs} role="tablist">
+        {items.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            role="tab"
+            aria-selected={range === item.value}
+            className={clsx(
+              styles.rangeTab,
+              range === item.value && styles.rangeTabActive
+            )}
+            onClick={() => onChange(item.value)}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function flagEmoji(code: string): string {
+  if (!code || code.length !== 2) return '';
+  return String.fromCodePoint(
+    ...[...code.toUpperCase()].map((c) => c.charCodeAt(0) + 127397)
+  );
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function PageviewsChart({ range }: { range: InsightsRange }) {
+  const { data, status } = useUmamiPageviewsSeries(range);
+  const series = data?.pageviews ?? [];
+  const loading = status === 'loading';
+
+  return (
+    <section className={styles.chartSection}>
+      <header className={styles.chartHead}>
+        <h2 className={styles.sectionTitle}>
+          {translate({
+            id: 'pages.insights.chart.title',
+            message: 'Pageviews over time',
+          })}
+        </h2>
+      </header>
+      <div className={styles.chartCard}>
+        <Sparkline data={series} loading={loading} />
+      </div>
+    </section>
+  );
+}
+
+function MetricsGrid({ range }: { range: InsightsRange }) {
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext();
+  const lang = currentLocale === 'zh-Hans' ? 'zh' : 'en';
+
+  const pages = useUmamiMetric('path', range);
+  const referrers = useUmamiMetric('referrer', range);
+  const countriesMetric = useUmamiMetric('country', range);
+  const devices = useUmamiMetric('device', range);
+
+  return (
+    <section className={styles.metricsGrid}>
+      <MetricList
+        title={translate({
+          id: 'pages.insights.metricList.pages',
+          message: 'Top pages',
+        })}
+        icon="lucide:file-text"
+        items={pages.items}
+        loading={pages.status === 'loading'}
+        emptyText={translate({
+          id: 'pages.insights.metricList.empty',
+          message: 'No data yet',
+        })}
+        renderLabel={(p) => <span title={p}>{p === '/' ? '/' : p}</span>}
+      />
+      <MetricList
+        title={translate({
+          id: 'pages.insights.metricList.referrers',
+          message: 'Top referrers',
+        })}
+        icon="lucide:link"
+        items={referrers.items}
+        loading={referrers.status === 'loading'}
+        emptyText={translate({
+          id: 'pages.insights.metricList.empty',
+          message: 'No data yet',
+        })}
+        renderLabel={(r) =>
+          r ? (
+            <span title={r}>{r}</span>
+          ) : (
+            <span className={styles.muted}>
+              {translate({
+                id: 'pages.insights.metricList.referrers.direct',
+                message: 'Direct',
+              })}
+            </span>
+          )
+        }
+      />
+      <MetricList
+        title={translate({
+          id: 'pages.insights.metricList.countries',
+          message: 'Top countries',
+        })}
+        icon="lucide:globe"
+        items={countriesMetric.items}
+        loading={countriesMetric.status === 'loading'}
+        emptyText={translate({
+          id: 'pages.insights.metricList.empty',
+          message: 'No data yet',
+        })}
+        renderLabel={(code) => (
+          <>
+            <span className={metricListStyles.flag} aria-hidden="true">
+              {flagEmoji(code)}
+            </span>
+            <span>{countries.getName(code, lang) || code}</span>
+          </>
+        )}
+      />
+      <MetricList
+        title={translate({
+          id: 'pages.insights.metricList.devices',
+          message: 'Devices',
+        })}
+        icon="lucide:smartphone"
+        items={devices.items}
+        loading={devices.status === 'loading'}
+        emptyText={translate({
+          id: 'pages.insights.metricList.empty',
+          message: 'No data yet',
+        })}
+        renderLabel={(d) => <span>{capitalize(d)}</span>}
+      />
+    </section>
+  );
+}
+
+function InsightsHeader() {
+  return (
+    <PageHeader>
+      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+    </PageHeader>
+  );
+}
+
+function InsightsMain() {
+  const [range, setRange] = useState<InsightsRange>(30);
+  return (
+    <main className={styles.container}>
+      <UptimeSection />
+      <RangeBar range={range} onChange={setRange} />
+      <HeroGrid range={range} />
+      <PageviewsChart range={range} />
+      <MetricsGrid range={range} />
+    </main>
+  );
+}
+
+export default function Insights(): ReactNode {
+  return (
+    <Layout title={TITLE} description={DESCRIPTION}>
+      <InsightsHeader />
+      <InsightsMain />
+    </Layout>
+  );
+}

--- a/src/pages/insights/styles.module.css
+++ b/src/pages/insights/styles.module.css
@@ -1,0 +1,213 @@
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3rem);
+}
+
+.rangeBar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.rangeTabs {
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.3rem;
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 14px;
+}
+
+html[data-theme='dark'] .rangeTabs {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.rangeTab {
+  appearance: none;
+  border: none;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 0.88rem;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition:
+    color 200ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease;
+}
+
+.rangeTab:hover {
+  color: var(--ifm-color-emphasis-900);
+}
+
+.rangeTabActive,
+.rangeTabActive:hover {
+  background: var(--ifm-card-background-color);
+  color: var(--ifm-color-primary);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.04),
+    0 4px 12px rgba(0, 0, 0, 0.06);
+}
+
+html[data-theme='dark'] .rangeTabActive,
+html[data-theme='dark'] .rangeTabActive:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-primary-light);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.heroTile {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 18px;
+  padding: 1.5rem 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  transition:
+    border-color 200ms ease,
+    box-shadow 200ms ease,
+    transform 200ms ease;
+}
+
+.heroTile:hover {
+  border-color: var(--ifm-color-emphasis-300);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.07);
+  transform: translateY(-2px);
+}
+
+.heroLabel {
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.heroValue {
+  font-size: clamp(1.75rem, 2vw + 0.6rem, 2.5rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--ifm-font-color-base);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.heroDeltaUp,
+.heroDeltaDown,
+.heroDeltaFlat {
+  font-size: 0.85rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.heroDeltaUp {
+  color: #1a8754;
+}
+
+.heroDeltaDown {
+  color: #d93838;
+}
+
+.heroDeltaFlat {
+  color: var(--ifm-color-emphasis-500);
+}
+
+html[data-theme='dark'] .heroDeltaUp {
+  color: #34c77b;
+}
+
+html[data-theme='dark'] .heroDeltaDown {
+  color: #ff6b6b;
+}
+
+.skeletonText {
+  position: relative;
+  color: transparent;
+  border-radius: 8px;
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-emphasis-100) 0%,
+    var(--ifm-color-emphasis-200) 50%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .heroGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.sectionTitle {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+  color: var(--ifm-font-color-base);
+}
+
+.chartSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chartHead {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.chartCard {
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 18px;
+  padding: 1.25rem;
+}
+
+.metricsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 640px) {
+  .metricsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.muted {
+  color: var(--ifm-color-emphasis-500);
+  font-style: italic;
+}

--- a/src/utils/kuma.ts
+++ b/src/utils/kuma.ts
@@ -1,0 +1,62 @@
+const KUMA_BASE = 'https://status.lailai.one';
+const KUMA_STATUS_SLUG = 'monitor';
+
+export interface KumaMonitor {
+  id: number;
+  name: string;
+  sendUrl?: number;
+  type?: string;
+}
+
+export interface KumaPublicGroup {
+  id: number;
+  name: string;
+  weight: number;
+  monitorList: KumaMonitor[];
+}
+
+export interface KumaStatusPageData {
+  config: {
+    slug: string;
+    title: string;
+    description?: string | null;
+    icon?: string;
+    theme?: string;
+    customCSS?: string;
+  };
+  incident: unknown | null;
+  publicGroupList: KumaPublicGroup[];
+  maintenanceList: unknown[];
+}
+
+export interface KumaHeartbeat {
+  status: 0 | 1 | 2 | 3;
+  time: string;
+  msg?: string;
+  ping?: number;
+}
+
+export interface KumaHeartbeatData {
+  heartbeatList: Record<string, KumaHeartbeat[]>;
+  uptimeList: Record<string, number>;
+}
+
+async function kumaFetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${KUMA_BASE}${path}`);
+  if (!res.ok) {
+    throw new Error(`Kuma request failed: ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export function getStatusPage(): Promise<KumaStatusPageData> {
+  return kumaFetchJson<KumaStatusPageData>(
+    `/api/status-page/${encodeURIComponent(KUMA_STATUS_SLUG)}`
+  );
+}
+
+export function getHeartbeats(): Promise<KumaHeartbeatData> {
+  return kumaFetchJson<KumaHeartbeatData>(
+    `/api/status-page/heartbeat/${encodeURIComponent(KUMA_STATUS_SLUG)}`
+  );
+}


### PR DESCRIPTION
## Summary

A new `/insights` page that combines self-hosted Umami visitor stats with Uptime Kuma monitor health, in one Apple-styled dashboard. No navbar/footer entry was added (per request) — the page is reachable directly at `/insights`.

## Layout

1. **System status** — overall pill (`All systems operational` / `Partial outage` / `Major outage` / `Under maintenance` / `Status unknown`) plus a row per monitor with last-60 heartbeat bar, 24h uptime, and average ping.
2. **Range selector** — 7 days / 30 days / 1 year. Switching reanimates every metric and chart below.
3. **Hero grid** — Pageviews, Visitors, Visits, Avg. Visit, Bounce Rate. Numbers count up on mount/range change. vs-prev-period delta sits beside each value; Bounce Rate inverts the color so "up" reads as bad.
4. **Pageviews-over-time sparkline** — pure SVG, cubic Bezier smoothing, accent-color gradient fill, stroke draw animation on mount, pulsing dot at the current point.
5. **Top lists** — Top pages, Top referrers, Top countries (with flag emoji), Devices. Each row has a subtle horizontal bar showing relative magnitude.

All sections have shimmer skeleton loading and a clean error fallback.

## Implementation

- Reuses the existing share-token flow in `src/utils/umami.ts`. Three new hooks (`useUmamiStats`, `useUmamiPageviewsSeries`, `useUmamiMetric`) plus `useKumaStatus` cover all data needs. All fetches run inside `useEffect` so server render outputs static placeholders.
- Country labels use the already-installed `i18n-iso-countries`, with `en` and `zh` registered upfront; `SG` resolves to "Singapore" / "新加坡" depending on locale.
- 30 new translation keys, all populated for `zh-Hans`.
- Changelog gets a 2026-05-01 entry linking to `/insights`.

## Reviewer notes

- **Kuma CORS in dev**: Caddy allows only `https://lailai.one`, so on `localhost` the System status section displays its error fallback. Once deployed, the request origin matches and the section renders normally. No code change needed.
- The page is added but not linked from navbar / footer. Add a navbar entry separately if desired.

## Test plan

- [ ] On the deployed site, `/insights` shows real data: hero numbers match Umami dashboard, sparkline matches the daily pageview series, top-N lists agree with Umami's own share view.
- [ ] System status pill turns green and lists the 5 published monitors with heartbeat bars; uptime % and ping populate.
- [ ] Range tabs (7d / 30d / 1y) refetch all sections and animate transitions.
- [ ] Mobile (375 wide): hero collapses to 2 columns, lists stack to 1 column, status pill wraps below title.
- [ ] Light / dark theme both legible; numbers are tabular; cards lift on hover.
- [ ] Switching site language to 简体中文 swaps the labels and country names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)