### PR TITLE
Use laikit/Card on the insights page

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -71,7 +71,6 @@
   "pages.friends.datacard.label": {
     "message": "位朋友"
   },
-
   "pages.insights.title": {
     "message": "实时洞察"
   },

--- a/src/pages/insights/_components/MetricList.module.css
+++ b/src/pages/insights/_components/MetricList.module.css
@@ -1,20 +1,8 @@
 .card {
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 18px;
-  padding: 1.5rem 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   min-height: 320px;
-  transition:
-    border-color 200ms ease,
-    box-shadow 200ms ease;
-}
-
-.card:hover {
-  border-color: var(--ifm-color-emphasis-300);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.06);
 }
 
 .head {

--- a/src/pages/insights/_components/MetricList.tsx
+++ b/src/pages/insights/_components/MetricList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Icon } from '@iconify/react';
+import Card from '@site/src/components/laikit/Card';
 import styles from './MetricList.module.css';
 
 export interface MetricRow {
@@ -36,7 +37,7 @@ export default function MetricList({
   const max = items.length > 0 ? Math.max(...items.map((i) => i.y), 1) : 1;
 
   return (
-    <section className={styles.card}>
+    <Card padding="1.5rem 1.25rem" className={styles.card}>
       <header className={styles.head}>
         <Icon icon={icon} className={styles.icon} />
         <h3 className={styles.title}>{title}</h3>
@@ -70,6 +71,6 @@ export default function MetricList({
           </ol>
         )}
       </div>
-    </section>
+    </Card>
   );
 }

--- a/src/pages/insights/_components/UptimeSection.module.css
+++ b/src/pages/insights/_components/UptimeSection.module.css
@@ -90,21 +90,9 @@ html[data-theme='dark'] .pillMaintenance {
 }
 
 .row {
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 16px;
-  padding: 1.1rem 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  transition:
-    border-color 200ms ease,
-    box-shadow 200ms ease;
-}
-
-.row:hover {
-  border-color: var(--ifm-color-emphasis-300);
-  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.05);
 }
 
 .rowHead {

--- a/src/pages/insights/_components/UptimeSection.tsx
+++ b/src/pages/insights/_components/UptimeSection.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Icon } from '@iconify/react';
 import { translate } from '@docusaurus/Translate';
+import Card from '@site/src/components/laikit/Card';
 import { useKumaStatus } from '@site/src/hooks/useKumaStatus';
 import type { KumaHeartbeat, KumaMonitor } from '@site/src/utils/kuma';
 import HeartbeatBar from './HeartbeatBar';
@@ -125,7 +126,7 @@ function MonitorRow({
             : styles.dotEmpty;
 
   return (
-    <div className={styles.row}>
+    <Card padding="1.1rem 1.25rem" className={styles.row}>
       <div className={styles.rowHead}>
         <span className={`${styles.dot} ${statusCls}`} aria-hidden="true" />
         <span className={styles.name}>{monitor.name}</span>
@@ -162,7 +163,7 @@ function MonitorRow({
           </span>
         )}
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -6,6 +6,7 @@ import * as countries from 'i18n-iso-countries';
 import countriesEn from 'i18n-iso-countries/langs/en.json';
 import countriesZh from 'i18n-iso-countries/langs/zh.json';
 import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import Card from '@site/src/components/laikit/Card';
 import {
   useUmamiStats,
   type InsightsRange,
@@ -115,7 +116,7 @@ function HeroMetric({
     sign === 'flat' ? null : spec.invertDelta ? sign === 'down' : sign === 'up';
 
   return (
-    <div className={styles.heroTile}>
+    <Card padding="1.5rem 1.5rem 1.25rem" className={styles.heroTile}>
       <span className={styles.heroLabel}>{spec.label}</span>
       <span
         className={
@@ -134,7 +135,7 @@ function HeroMetric({
       {!loading && (delta == null || sign === 'flat') && (
         <span className={styles.heroDeltaFlat}>—</span>
       )}
-    </div>
+    </Card>
   );
 }
 
@@ -286,9 +287,9 @@ function PageviewsChart({ range }: { range: InsightsRange }) {
           })}
         </h2>
       </header>
-      <div className={styles.chartCard}>
+      <Card padding="1.25rem">
         <Sparkline data={series} loading={loading} />
-      </div>
+      </Card>
     </section>
   );
 }

--- a/src/pages/insights/styles.module.css
+++ b/src/pages/insights/styles.module.css
@@ -71,22 +71,13 @@ html[data-theme='dark'] .rangeTabActive:hover {
 }
 
 .heroTile {
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 18px;
-  padding: 1.5rem 1.5rem 1.25rem;
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  transition:
-    border-color 200ms ease,
-    box-shadow 200ms ease,
-    transform 200ms ease;
+  transition: transform 200ms ease;
 }
 
 .heroTile:hover {
-  border-color: var(--ifm-color-emphasis-300);
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.07);
   transform: translateY(-2px);
 }
 
@@ -186,13 +177,6 @@ html[data-theme='dark'] .heroDeltaDown {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-}
-
-.chartCard {
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 18px;
-  padding: 1.25rem;
 }
 
 .metricsGrid {


### PR DESCRIPTION
## Summary

Replace four hand-rolled card surfaces on \`/insights\` with the existing [laikit/Card](src/components/laikit/Card/index.tsx) component:

- Hero metric tiles (Pageviews / Visitors / Visits / Avg. Visit / Bounce Rate)
- Pageviews-over-time sparkline wrapper
- MetricList card (Top pages / referrers / countries / devices)
- Uptime monitor row

## Why

#30 (Tighten visual unity: add LinkCard, prune redundant Card overrides) cleaned up scattered card overrides in favor of the laikit/Card component. The newly-added insights page reintroduced four bespoke surfaces with slightly different radii (18px vs 16px) and stronger hover shadows. This PR folds them back into the shared component so /insights matches the rest of the site and picks up future Card-level changes for free.

## What changed

- Each card uses \`<Card padding="…" className={…}>\`, with the per-card className keeping only layout (flex direction, gap, min-height) and behavior (hover lift on hero tiles).
- Background, border, border-radius, padding, and base shadow are no longer duplicated — they come from Card.
- Net diff is **+12 / −50** lines.

## Reviewer notes

- The \`i18n/zh-Hans/code.json\` reorder is just \`npm run check\` rewriting key order to match source-discovery order. No string changes.
- Verified locally: 10 \`[class*="card_"]\` instances under \`<main>\` all render with the canonical \`16px\` radius and \`0 6px 16px rgba(0,0,0,0.06)\` shadow.

## Test plan

- [ ] \`/insights\` looks identical to before in light and dark mode, just with consistent corner radius and shadow depth across all sections.
- [ ] Hover on hero tiles still lifts them by 2px.
- [ ] Range tabs / sparkline / metric lists all behave the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)