### PR TITLE
Refactor insights page; extract laikit/Skeleton + PageContent

### DIFF
--- a/src/components/laikit/Page/index.tsx
+++ b/src/components/laikit/Page/index.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { type ElementType, type ReactNode } from 'react';
+import clsx from 'clsx';
 import Heading from '@theme/Heading';
 import styles from './styles.module.css';
 
@@ -26,5 +27,19 @@ export function PageHeader({ children }: { children: React.ReactNode }) {
     <div className={styles.headerSection}>
       <div className={styles.headerInner}>{children}</div>
     </div>
+  );
+}
+
+export function PageContent({
+  as: Tag = 'main',
+  className,
+  children,
+}: {
+  as?: ElementType;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Tag className={clsx(styles.pageContent, className)}>{children}</Tag>
   );
 }

--- a/src/components/laikit/Page/styles.module.css
+++ b/src/components/laikit/Page/styles.module.css
@@ -1,3 +1,10 @@
+.pageContent {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: clamp(2rem, 4vw, 3rem) clamp(1rem, 3vw, 2rem);
+}
+
 .headerSection {
   background-color: var(--ifm-background-color);
   border-bottom: 1px solid var(--ifm-color-emphasis-200);

--- a/src/components/laikit/Segmented/index.tsx
+++ b/src/components/laikit/Segmented/index.tsx
@@ -13,6 +13,7 @@ interface SegmentedProps<T> {
   value: T;
   items: SegmentedItem<T>[];
   onChange: (value: T) => void;
+  orientation?: 'vertical' | 'horizontal';
   className?: string;
 }
 
@@ -20,10 +21,17 @@ export default function Segmented<T>({
   value,
   items,
   onChange,
+  orientation = 'vertical',
   className,
 }: SegmentedProps<T>) {
   return (
-    <div className={clsx(styles.segmented, className)}>
+    <div
+      className={clsx(
+        styles.segmented,
+        orientation === 'horizontal' && styles.horizontal,
+        className
+      )}
+    >
       {items.map((item) => (
         <button
           key={String(item.value ?? '__null__')}

--- a/src/components/laikit/Segmented/styles.module.css
+++ b/src/components/laikit/Segmented/styles.module.css
@@ -8,6 +8,39 @@
   border-radius: 14px;
 }
 
+.horizontal {
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.25rem;
+}
+
+.horizontal .item {
+  text-align: center;
+  padding: 0.5rem 1rem;
+}
+
+.horizontal .label {
+  flex: none;
+}
+
+@media (max-width: 480px) {
+  .horizontal {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: 0.35rem;
+  }
+
+  .horizontal .item {
+    text-align: left;
+    padding: 0.6rem 0.85rem;
+  }
+
+  .horizontal .label {
+    flex: 1;
+  }
+}
+
 html[data-theme='dark'] .segmented {
   background: rgba(255, 255, 255, 0.03);
   border-color: var(--ifm-color-emphasis-200);

--- a/src/components/laikit/Skeleton/index.tsx
+++ b/src/components/laikit/Skeleton/index.tsx
@@ -1,0 +1,26 @@
+import React, { type CSSProperties } from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+interface SkeletonProps {
+  width?: number | string;
+  height?: number | string;
+  radius?: number | string;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export default function Skeleton({
+  width,
+  height,
+  radius,
+  className,
+  style,
+}: SkeletonProps) {
+  return (
+    <div
+      className={clsx(styles.skeleton, className)}
+      style={{ width, height, borderRadius: radius, ...style }}
+    />
+  );
+}

--- a/src/components/laikit/Skeleton/styles.module.css
+++ b/src/components/laikit/Skeleton/styles.module.css
@@ -1,0 +1,19 @@
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--ifm-color-emphasis-100) 0%,
+    var(--ifm-color-emphasis-200) 50%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/src/hooks/useUmamiMetric.ts
+++ b/src/hooks/useUmamiMetric.ts
@@ -19,7 +19,10 @@ export function useUmamiMetric(
 
   useEffect(() => {
     const controller = new AbortController();
-    const endAt = Date.now();
+    const endAt =
+      range === 1
+        ? Math.ceil(Date.now() / 3600_000) * 3600_000
+        : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
 
     (async () => {

--- a/src/hooks/useUmamiPageviewsSeries.ts
+++ b/src/hooks/useUmamiPageviewsSeries.ts
@@ -14,30 +14,150 @@ interface PageviewsResponse {
   sessions: SeriesPoint[];
 }
 
+function rangeUnit(range: InsightsRange): SeriesUnit {
+  if (range === 1 || range === 7) return 'hour';
+  return 'day';
+}
+
+function mergeSeries(parts: SeriesPoint[][]): SeriesPoint[] {
+  const seen = new Map<string, SeriesPoint>();
+  for (const arr of parts) {
+    for (const pt of arr) {
+      seen.set(pt.x, pt);
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.x.localeCompare(b.x));
+}
+
+function pad2(n: number) {
+  return n.toString().padStart(2, '0');
+}
+
+function bucketKey(d: Date, unit: SeriesUnit): string {
+  const date = `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+  if (unit === 'hour') return `${date} ${pad2(d.getHours())}:00:00`;
+  return `${date} 00:00:00`;
+}
+
+function nextBucket(d: Date, unit: SeriesUnit): Date {
+  const c = new Date(d);
+  if (unit === 'hour') c.setHours(c.getHours() + 1);
+  else c.setDate(c.getDate() + 1);
+  return c;
+}
+
+function downsample(arr: SeriesPoint[], windowSize: number): SeriesPoint[] {
+  if (windowSize <= 1) return arr;
+  const out: SeriesPoint[] = [];
+  for (let i = 0; i < arr.length; i += windowSize) {
+    const slice = arr.slice(i, i + windowSize);
+    if (slice.length === 0) continue;
+    out.push({
+      x: slice[0].x,
+      y: slice.reduce((s, p) => s + p.y, 0),
+    });
+  }
+  return out;
+}
+
+function weekKey(iso: string): string {
+  const d = new Date(iso.replace(' ', 'T'));
+  const offset = (d.getDay() + 6) % 7;
+  d.setDate(d.getDate() - offset);
+  return bucketKey(d, 'day');
+}
+
+function aggregateByWeek(arr: SeriesPoint[]): SeriesPoint[] {
+  const buckets = new Map<string, number>();
+  for (const p of arr) {
+    const k = weekKey(p.x);
+    buckets.set(k, (buckets.get(k) ?? 0) + p.y);
+  }
+  return [...buckets.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([x, y]) => ({ x, y }));
+}
+
+function fillSeries(
+  arr: SeriesPoint[],
+  unit: SeriesUnit,
+  startAt?: number,
+  endAt?: number
+): SeriesPoint[] {
+  if (unit === 'month') return arr;
+  let start: Date;
+  let end: Date;
+  if (startAt != null && endAt != null) {
+    start = new Date(startAt);
+    end = new Date(endAt - 1);
+    if (unit === 'hour') {
+      start.setMinutes(0, 0, 0);
+      end.setMinutes(0, 0, 0);
+    } else {
+      start.setHours(0, 0, 0, 0);
+      end.setHours(0, 0, 0, 0);
+    }
+  } else if (arr.length >= 2) {
+    start = new Date(arr[0].x.replace(' ', 'T'));
+    end = new Date(arr[arr.length - 1].x.replace(' ', 'T'));
+  } else {
+    return arr;
+  }
+  const have = new Map(arr.map((p) => [p.x, p.y]));
+  const out: SeriesPoint[] = [];
+  for (let d = start; d.getTime() <= end.getTime(); d = nextBucket(d, unit)) {
+    const x = bucketKey(d, unit);
+    out.push({ x, y: have.get(x) ?? 0 });
+  }
+  return out;
+}
+
 export function useUmamiPageviewsSeries(range: InsightsRange) {
   const [data, setData] = useState<PageviewsResponse | null>(null);
   const [status, setStatus] = useState<FetchStatus>('loading');
 
   useEffect(() => {
     const controller = new AbortController();
-    const endAt = Date.now();
+    const endAt =
+      range === 1
+        ? Math.ceil(Date.now() / 3600_000) * 3600_000
+        : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
-    const unit: SeriesUnit = 'day';
+    const unit = rangeUnit(range);
     const timezone =
       typeof Intl !== 'undefined'
         ? Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
         : 'UTC';
 
+    const fetchSeg = (segStart: number, segEnd: number) =>
+      umamiFetchJson<PageviewsResponse>(
+        '/api/websites/{id}/pageviews',
+        { startAt: segStart, endAt: segEnd, unit, timezone },
+        { signal: controller.signal }
+      );
+
     (async () => {
       setStatus('loading');
       try {
-        const result = await umamiFetchJson<PageviewsResponse>(
-          '/api/websites/{id}/pageviews',
-          { startAt, endAt, unit, timezone },
-          { signal: controller.signal }
-        );
+        // Umami caps day-resolution at ~200 days; chunk longer ranges in two.
+        const needsChunk = range > 200 && unit === 'day';
+        const parts: PageviewsResponse[] = needsChunk
+          ? await Promise.all([
+              fetchSeg(startAt, startAt + (endAt - startAt) / 2),
+              fetchSeg(startAt + (endAt - startAt) / 2 + 1, endAt),
+            ])
+          : [await fetchSeg(startAt, endAt)];
         if (controller.signal.aborted) return;
-        setData(result);
+        const reduce = (merged: SeriesPoint[]) => {
+          const filled = fillSeries(merged, unit, startAt, endAt);
+          if (range === 7) return downsample(filled, 6);
+          if (range === 365) return aggregateByWeek(filled);
+          return filled;
+        };
+        setData({
+          pageviews: reduce(mergeSeries(parts.map((p) => p.pageviews))),
+          sessions: reduce(mergeSeries(parts.map((p) => p.sessions))),
+        });
         setStatus('success');
       } catch (error) {
         if (controller.signal.aborted) return;

--- a/src/hooks/useUmamiStats.ts
+++ b/src/hooks/useUmamiStats.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { umamiFetchJson } from '@site/src/utils/umami';
 
-export type InsightsRange = 7 | 30 | 365;
+export type InsightsRange = 1 | 7 | 30 | 365;
 
 export interface UmamiStats {
   pageviews: number;
@@ -23,7 +23,10 @@ export function useUmamiStats(range: InsightsRange) {
 
   useEffect(() => {
     const controller = new AbortController();
-    const endAt = Date.now();
+    const endAt =
+      range === 1
+        ? Math.ceil(Date.now() / 3600_000) * 3600_000
+        : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
 
     (async () => {

--- a/src/pages/friends/index.tsx
+++ b/src/pages/friends/index.tsx
@@ -1,6 +1,10 @@
 import React, { type ReactNode } from 'react';
 import Layout from '@theme/Layout';
-import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  PageTitle,
+  PageHeader,
+  PageContent,
+} from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import LinkCard from '@site/src/components/laikit/LinkCard';
 import { FriendItem, FRIEND_LIST } from '@site/src/data/friends';
@@ -35,11 +39,11 @@ function FriendCard({ friend }: { friend: FriendItem }) {
 
 function FriendsMain() {
   return (
-    <div className={styles.container}>
+    <PageContent className={styles.layout}>
       {FRIEND_LIST.map((friend, index) => (
         <FriendCard key={`${friend.title}-${index}`} friend={friend} />
       ))}
-    </div>
+    </PageContent>
   );
 }
 

--- a/src/pages/friends/styles.module.css
+++ b/src/pages/friends/styles.module.css
@@ -1,26 +1,5 @@
-/* Layout */
-
-.container {
+.layout {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
   gap: 1.5rem;
-
-  width: 100%;
-  max-width: 1200px;
-  margin: auto;
-  padding: 2rem;
-}
-
-/* Responsive */
-
-@media (max-width: 1199px) {
-  .container {
-    padding: 1.5rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .container {
-    padding: 1rem;
-  }
 }

--- a/src/pages/insights/_components/MetricList.module.css
+++ b/src/pages/insights/_components/MetricList.module.css
@@ -44,12 +44,20 @@
   display: flex;
   align-items: center;
   padding: 0.55rem 0.75rem;
-  border-radius: 10px;
   font-size: 0.92rem;
+}
+
+.row::before {
+  content: '';
+  position: absolute;
+  inset: 4px 0;
+  border-radius: 8px;
+  background: transparent;
+  pointer-events: none;
   transition: background 160ms ease;
 }
 
-.row:hover {
+.row:hover::before {
   background: var(--ifm-color-emphasis-100);
 }
 
@@ -70,6 +78,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--ifm-color-emphasis-900);
+  font-weight: 500;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -94,32 +103,20 @@
 .skeletonList {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.15rem;
 }
 
 .skeletonRow {
-  height: 32px;
-  border-radius: 10px;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-emphasis-100) 0%,
-    var(--ifm-color-emphasis-200) 50%,
-    var(--ifm-color-emphasis-100) 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
+  composes: skeleton from '../../../components/laikit/Skeleton/styles.module.css';
+  height: 42px;
+  border-radius: 8px;
 }
 
 .flag {
-  font-size: 1.05rem;
+  width: 20px;
+  height: 15px;
+  object-fit: cover;
+  border-radius: 2px;
   flex-shrink: 0;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.06);
 }

--- a/src/pages/insights/_components/MetricList.tsx
+++ b/src/pages/insights/_components/MetricList.tsx
@@ -37,7 +37,7 @@ export default function MetricList({
   const max = items.length > 0 ? Math.max(...items.map((i) => i.y), 1) : 1;
 
   return (
-    <Card padding="1.5rem 1.25rem" className={styles.card}>
+    <Card padding="1.5rem 1.25rem 1.25rem" className={styles.card}>
       <header className={styles.head}>
         <Icon icon={icon} className={styles.icon} />
         <h3 className={styles.title}>{title}</h3>
@@ -45,7 +45,7 @@ export default function MetricList({
       <div className={styles.body}>
         {loading ? (
           <div className={styles.skeletonList}>
-            {Array.from({ length: 5 }).map((_, i) => (
+            {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className={styles.skeletonRow} />
             ))}
           </div>

--- a/src/pages/insights/_components/Sparkline.module.css
+++ b/src/pages/insights/_components/Sparkline.module.css
@@ -1,8 +1,16 @@
+.wrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .sparkline {
   position: relative;
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
   border-radius: 14px;
+  cursor: crosshair;
 }
 
 .svg {
@@ -11,9 +19,21 @@
   display: block;
 }
 
+.grid {
+  stroke: var(--ifm-color-emphasis-300);
+  stroke-width: 1;
+  stroke-dasharray: 3 4;
+  opacity: 0.55;
+}
+
+html[data-theme='dark'] .grid {
+  stroke: var(--ifm-color-emphasis-400);
+  opacity: 0.4;
+}
+
 .line {
-  stroke-dasharray: 3000;
-  stroke-dashoffset: 3000;
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
   animation: draw 1100ms cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
@@ -23,43 +43,78 @@
   }
 }
 
-.pulse {
-  transform-origin: center;
-  transform-box: fill-box;
-  animation: pulse 2.4s ease-in-out infinite;
+.crosshair {
+  stroke: var(--ifm-color-emphasis-500);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+  opacity: 0.7;
+  pointer-events: none;
 }
 
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.18;
-  }
-  50% {
-    transform: scale(1.6);
-    opacity: 0;
-  }
+.tooltip {
+  position: absolute;
+  top: -8px;
+  transform: translate(-50%, -100%);
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 0.4rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  white-space: nowrap;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  z-index: 2;
+}
+
+html[data-theme='dark'] .tooltip {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.tooltipDate {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  letter-spacing: 0.02em;
+}
+
+.tooltipValue {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ifm-font-color-base);
+  font-variant-numeric: tabular-nums;
+}
+
+.xAxis {
+  position: relative;
+  width: 100%;
+  height: 1rem;
+}
+
+.xTick {
+  position: absolute;
+  transform: translateX(-50%);
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+
+.xTick:first-child {
+  transform: translateX(0);
+}
+
+.xTick:last-child {
+  transform: translateX(-100%);
 }
 
 .skeleton {
+  composes: skeleton from '../../../components/laikit/Skeleton/styles.module.css';
   width: 100%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-emphasis-100) 0%,
-    var(--ifm-color-emphasis-200) 50%,
-    var(--ifm-color-emphasis-100) 100%
-  );
-  background-size: 200% 100%;
   border-radius: 14px;
-  animation: shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
 }

--- a/src/pages/insights/_components/Sparkline.tsx
+++ b/src/pages/insights/_components/Sparkline.tsx
@@ -1,11 +1,15 @@
-import React, { useId, useMemo } from 'react';
+import React, { useId, useMemo, useRef, useState } from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type { SeriesPoint } from '@site/src/hooks/useUmamiPageviewsSeries';
 import styles from './Sparkline.module.css';
+
+type SparklineUnit = 'hour' | '6h' | 'day' | 'week';
 
 interface SparklineProps {
   data: SeriesPoint[];
   height?: number;
   loading?: boolean;
+  unit?: SparklineUnit;
 }
 
 function buildPath(
@@ -40,104 +44,282 @@ function buildPath(
   return { line, area };
 }
 
+function parseDate(iso: string): Date {
+  return new Date(iso.replace(' ', 'T'));
+}
+
+function formatTick(
+  iso: string,
+  unit: SparklineUnit,
+  spanDays: number,
+  locale: string
+): string {
+  const d = parseDate(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  if (unit === 'hour' && spanDays <= 1.5) {
+    return d.toLocaleTimeString(locale, {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+  }
+  return d.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatHM(d: Date, locale: string): string {
+  return d.toLocaleTimeString(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+}
+
+function formatMD(d: Date, locale: string): string {
+  return d.toLocaleDateString(locale, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatYMD(d: Date, locale: string): string {
+  return d.toLocaleDateString(locale, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function formatTooltipDate(
+  iso: string,
+  unit: SparklineUnit,
+  locale: string
+): string {
+  const d = parseDate(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  if (unit === 'hour') {
+    const end = new Date(d);
+    end.setHours(end.getHours() + 1);
+    return `${formatMD(d, locale)} ${formatHM(d, locale)} – ${formatHM(end, locale)}`;
+  }
+  if (unit === '6h') {
+    const end = new Date(d);
+    end.setHours(end.getHours() + 6);
+    const sameDay =
+      d.getFullYear() === end.getFullYear() &&
+      d.getMonth() === end.getMonth() &&
+      d.getDate() === end.getDate();
+    const endLabel = sameDay
+      ? formatHM(end, locale)
+      : `${formatMD(end, locale)} ${formatHM(end, locale)}`;
+    return `${formatMD(d, locale)} ${formatHM(d, locale)} – ${endLabel}`;
+  }
+  if (unit === 'week') {
+    const end = new Date(d);
+    end.setDate(end.getDate() + 6);
+    return `${formatMD(d, locale)} – ${formatYMD(end, locale)}`;
+  }
+  return formatYMD(d, locale);
+}
+
+function formatCompact(n: number): string {
+  return new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(n);
+}
+
 export default function Sparkline({
   data,
   height = 220,
   loading = false,
+  unit = 'day',
 }: SparklineProps) {
   const gradientId = useId();
   const width = 1200;
   const padding = 8;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext();
+  const locale = currentLocale === 'zh-Hans' ? 'zh' : 'en';
 
   const values = useMemo(() => data.map((d) => d.y), [data]);
   const { line, area } = useMemo(
     () => buildPath(values, width, height, padding),
-    [values, width, height, padding]
+    [values, width, height]
   );
 
+  const max = values.length ? Math.max(...values, 1) : 1;
+  const min = values.length ? Math.min(...values, 0) : 0;
+  const span = max - min || 1;
+  const innerH = height - padding * 2;
+  const innerW = width - padding * 2;
+  const stepX = values.length > 1 ? innerW / (values.length - 1) : 0;
+
+  const xAt = (i: number) => padding + i * stepX;
+  const yAt = (v: number) => padding + innerH - ((v - min) / span) * innerH;
+
   const lastIndex = values.length - 1;
-  const lastDot =
-    values.length > 0
-      ? {
-          x:
-            padding +
-            (values.length > 1
-              ? (lastIndex * (width - padding * 2)) / (values.length - 1)
-              : (width - padding * 2) / 2),
-          y: (() => {
-            const max = Math.max(...values, 1);
-            const min = Math.min(...values, 0);
-            const span = max - min || 1;
-            const innerH = height - padding * 2;
-            return (
-              padding + innerH - ((values[lastIndex] - min) / span) * innerH
-            );
-          })(),
-        }
+  const activeIdx = hoverIdx ?? lastIndex;
+  const activePoint =
+    values.length > 0 && activeIdx >= 0
+      ? { x: xAt(activeIdx), y: yAt(values[activeIdx]) }
       : null;
+
+  const gridLines = [0.25, 0.5, 0.75].map((r) => padding + innerH * r);
+  const tickIdxs =
+    values.length === 0
+      ? []
+      : values.length <= 3
+        ? values.map((_, i) => i)
+        : [0, Math.floor(lastIndex / 2), lastIndex];
+
+  const spanDays =
+    data.length > 1
+      ? (parseDate(data[lastIndex].x).getTime() - parseDate(data[0].x).getTime()) /
+        86400000
+      : 0;
+
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!containerRef.current || values.length === 0) return;
+    const rect = containerRef.current.getBoundingClientRect();
+    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    setHoverIdx(Math.round(ratio * lastIndex));
+  };
+  const onPointerLeave = () => setHoverIdx(null);
 
   if (loading || values.length === 0) {
     return (
-      <div className={styles.sparkline} style={{ height }}>
-        <div className={styles.skeleton} />
+      <div className={styles.wrapper}>
+        <div className={styles.sparkline} style={{ height }}>
+          <div className={styles.skeleton} />
+        </div>
+        <div className={styles.xAxis} aria-hidden="true" />
       </div>
     );
   }
 
+  const tooltipLeftPct = (activeIdx / Math.max(lastIndex, 1)) * 100;
+
   return (
-    <div className={styles.sparkline} style={{ height }}>
-      <svg
-        className={styles.svg}
-        viewBox={`0 0 ${width} ${height}`}
-        preserveAspectRatio="none"
-        aria-hidden="true"
+    <div className={styles.wrapper}>
+      <div
+        ref={containerRef}
+        className={styles.sparkline}
+        style={{ height }}
+        onPointerMove={onPointerMove}
+        onPointerLeave={onPointerLeave}
+        role="img"
+        aria-label="Pageviews over time"
       >
-        <defs>
-          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-            <stop
-              offset="0%"
-              stopColor="var(--ifm-color-primary)"
-              stopOpacity="0.32"
+        <svg
+          className={styles.svg}
+          viewBox={`0 0 ${width} ${height}`}
+          preserveAspectRatio="none"
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="0%"
+                stopColor="var(--ifm-color-primary)"
+                stopOpacity="0.32"
+              />
+              <stop
+                offset="100%"
+                stopColor="var(--ifm-color-primary)"
+                stopOpacity="0"
+              />
+            </linearGradient>
+          </defs>
+
+          {gridLines.map((y, i) => (
+            <line
+              key={i}
+              x1={padding}
+              x2={width - padding}
+              y1={y}
+              y2={y}
+              className={styles.grid}
+              vectorEffect="non-scaling-stroke"
             />
-            <stop
-              offset="100%"
-              stopColor="var(--ifm-color-primary)"
-              stopOpacity="0"
-            />
-          </linearGradient>
-        </defs>
-        <path d={area} fill={`url(#${gradientId})`} />
-        <path
-          d={line}
-          fill="none"
-          stroke="var(--ifm-color-primary)"
-          strokeWidth="2.5"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          vectorEffect="non-scaling-stroke"
-          className={styles.line}
-        />
-        {lastDot && (
-          <>
+          ))}
+
+          <path d={area} fill={`url(#${gradientId})`} />
+          <path
+            d={line}
+            fill="none"
+            stroke="var(--ifm-color-primary)"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+            pathLength={1}
+            className={styles.line}
+          />
+
+          {hoverIdx === null && activePoint && (
             <circle
-              cx={lastDot.x}
-              cy={lastDot.y}
-              r="9"
-              fill="var(--ifm-color-primary)"
-              opacity="0.18"
-              className={styles.pulse}
-            />
-            <circle
-              cx={lastDot.x}
-              cy={lastDot.y}
+              cx={activePoint.x}
+              cy={activePoint.y}
               r="4"
               fill="var(--ifm-color-primary)"
               stroke="var(--ifm-card-background-color)"
               strokeWidth="2"
             />
-          </>
+          )}
+
+          {hoverIdx !== null && activePoint && (
+            <>
+              <line
+                x1={activePoint.x}
+                x2={activePoint.x}
+                y1={padding}
+                y2={height - padding}
+                className={styles.crosshair}
+                vectorEffect="non-scaling-stroke"
+              />
+              <circle
+                cx={activePoint.x}
+                cy={activePoint.y}
+                r="5"
+                fill="var(--ifm-color-primary)"
+                stroke="var(--ifm-card-background-color)"
+                strokeWidth="2"
+              />
+            </>
+          )}
+        </svg>
+
+        {hoverIdx !== null && (
+          <div
+            className={styles.tooltip}
+            style={{ left: `${tooltipLeftPct}%` }}
+          >
+            <span className={styles.tooltipDate}>
+              {formatTooltipDate(data[activeIdx].x, unit, locale)}
+            </span>
+            <span className={styles.tooltipValue}>
+              {formatCompact(values[activeIdx])}
+            </span>
+          </div>
         )}
-      </svg>
+      </div>
+
+      <div className={styles.xAxis}>
+        {tickIdxs.map((i) => (
+          <span
+            key={i}
+            className={styles.xTick}
+            style={{ left: `${(i / Math.max(lastIndex, 1)) * 100}%` }}
+          >
+            {formatTick(data[i].x, unit, spanDays, locale)}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/insights/_components/UptimeSection.module.css
+++ b/src/pages/insights/_components/UptimeSection.module.css
@@ -179,25 +179,9 @@ html[data-theme='dark'] .dotDown {
 }
 
 .skeletonRow {
+  composes: skeleton from '../../../components/laikit/Skeleton/styles.module.css';
   height: 96px;
   border-radius: 16px;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-emphasis-100) 0%,
-    var(--ifm-color-emphasis-200) 50%,
-    var(--ifm-color-emphasis-100) 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
 }
 
 .empty {

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -1,12 +1,18 @@
 import React, { type ReactNode, useState } from 'react';
-import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import { translate } from '@docusaurus/Translate';
 import * as countries from 'i18n-iso-countries';
 import countriesEn from 'i18n-iso-countries/langs/en.json';
 import countriesZh from 'i18n-iso-countries/langs/zh.json';
-import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  PageTitle,
+  PageHeader,
+  PageContent,
+} from '@site/src/components/laikit/Page';
 import Card from '@site/src/components/laikit/Card';
+import Segmented, {
+  type SegmentedItem,
+} from '@site/src/components/laikit/Segmented';
 import {
   useUmamiStats,
   type InsightsRange,
@@ -16,6 +22,7 @@ import { useUmamiPageviewsSeries } from '@site/src/hooks/useUmamiPageviewsSeries
 import { useUmamiMetric } from '@site/src/hooks/useUmamiMetric';
 import { useAnimatedNumber } from '@site/src/hooks/useAnimatedNumber';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { Icon } from '@iconify/react';
 import Sparkline from './_components/Sparkline';
 import MetricList from './_components/MetricList';
 import metricListStyles from './_components/MetricList.module.css';
@@ -125,14 +132,15 @@ function HeroMetric({
             : styles.heroValue
         }
       >
-        {loading ? '0' : spec.format(animated)}
+        {loading ? '     ' : spec.format(animated)}
       </span>
-      {!loading && delta != null && sign !== 'flat' && (
+      {loading ? (
+        <span className={styles.heroDeltaFlat}>&nbsp;</span>
+      ) : delta != null && sign !== 'flat' ? (
         <span className={positive ? styles.heroDeltaUp : styles.heroDeltaDown}>
           {sign === 'up' ? '↑' : '↓'} {Math.abs(delta * 100).toFixed(1)}%
         </span>
-      )}
-      {!loading && (delta == null || sign === 'flat') && (
+      ) : (
         <span className={styles.heroDeltaFlat}>—</span>
       )}
     </Card>
@@ -214,7 +222,14 @@ function RangeBar({
   range: InsightsRange;
   onChange: (r: InsightsRange) => void;
 }) {
-  const items: { value: InsightsRange; label: string }[] = [
+  const items: SegmentedItem<InsightsRange>[] = [
+    {
+      value: 1,
+      label: translate({
+        id: 'pages.insights.range.1d',
+        message: '24 hours',
+      }),
+    },
     {
       value: 7,
       label: translate({
@@ -239,37 +254,18 @@ function RangeBar({
   ];
   return (
     <div className={styles.rangeBar}>
-      <div className={styles.rangeTabs} role="tablist">
-        {items.map((item) => (
-          <button
-            key={item.value}
-            type="button"
-            role="tab"
-            aria-selected={range === item.value}
-            className={clsx(
-              styles.rangeTab,
-              range === item.value && styles.rangeTabActive
-            )}
-            onClick={() => onChange(item.value)}
-          >
-            {item.label}
-          </button>
-        ))}
-      </div>
+      <Segmented<InsightsRange>
+        value={range}
+        items={items}
+        onChange={onChange}
+        orientation="horizontal"
+      />
     </div>
   );
 }
 
-function flagEmoji(code: string): string {
-  if (!code || code.length !== 2) return '';
-  return String.fromCodePoint(
-    ...[...code.toUpperCase()].map((c) => c.charCodeAt(0) + 127397)
-  );
-}
-
-function capitalize(s: string): string {
-  if (!s) return s;
-  return s.charAt(0).toUpperCase() + s.slice(1);
+function flagImageUrl(code: string): string {
+  return `https://analytics.lailai.one/images/country/${code.toLowerCase()}.png`;
 }
 
 function PageviewsChart({ range }: { range: InsightsRange }) {
@@ -278,19 +274,30 @@ function PageviewsChart({ range }: { range: InsightsRange }) {
   const loading = status === 'loading';
 
   return (
-    <section className={styles.chartSection}>
-      <header className={styles.chartHead}>
-        <h2 className={styles.sectionTitle}>
+    <Card padding="1.5rem 1.25rem 1.25rem" className={styles.chartCard}>
+      <header className={metricListStyles.head}>
+        <Icon icon="lucide:line-chart" className={metricListStyles.icon} />
+        <h3 className={metricListStyles.title}>
           {translate({
             id: 'pages.insights.chart.title',
             message: 'Pageviews over time',
           })}
-        </h2>
+        </h3>
       </header>
-      <Card padding="1.25rem">
-        <Sparkline data={series} loading={loading} />
-      </Card>
-    </section>
+      <Sparkline
+        data={series}
+        loading={loading}
+        unit={
+          range === 1
+            ? 'hour'
+            : range === 7
+              ? '6h'
+              : range === 30
+                ? 'day'
+                : 'week'
+        }
+      />
+    </Card>
   );
 }
 
@@ -303,7 +310,6 @@ function MetricsGrid({ range }: { range: InsightsRange }) {
   const pages = useUmamiMetric('path', range);
   const referrers = useUmamiMetric('referrer', range);
   const countriesMetric = useUmamiMetric('country', range);
-  const devices = useUmamiMetric('device', range);
 
   return (
     <section className={styles.metricsGrid}>
@@ -360,57 +366,35 @@ function MetricsGrid({ range }: { range: InsightsRange }) {
         })}
         renderLabel={(code) => (
           <>
-            <span className={metricListStyles.flag} aria-hidden="true">
-              {flagEmoji(code)}
-            </span>
+            <img
+              className={metricListStyles.flag}
+              src={flagImageUrl(code)}
+              alt=""
+              aria-hidden="true"
+              loading="lazy"
+            />
             <span>{countries.getName(code, lang) || code}</span>
           </>
         )}
-      />
-      <MetricList
-        title={translate({
-          id: 'pages.insights.metricList.devices',
-          message: 'Devices',
-        })}
-        icon="lucide:smartphone"
-        items={devices.items}
-        loading={devices.status === 'loading'}
-        emptyText={translate({
-          id: 'pages.insights.metricList.empty',
-          message: 'No data yet',
-        })}
-        renderLabel={(d) => <span>{capitalize(d)}</span>}
       />
     </section>
   );
 }
 
-function InsightsHeader() {
-  return (
-    <PageHeader>
-      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
-    </PageHeader>
-  );
-}
-
-function InsightsMain() {
-  const [range, setRange] = useState<InsightsRange>(30);
-  return (
-    <main className={styles.container}>
-      <UptimeSection />
-      <RangeBar range={range} onChange={setRange} />
-      <HeroGrid range={range} />
-      <PageviewsChart range={range} />
-      <MetricsGrid range={range} />
-    </main>
-  );
-}
-
 export default function Insights(): ReactNode {
+  const [range, setRange] = useState<InsightsRange>(1);
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <InsightsHeader />
-      <InsightsMain />
+      <PageHeader>
+        <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+        <RangeBar range={range} onChange={setRange} />
+      </PageHeader>
+      <PageContent className={styles.layout}>
+        <HeroGrid range={range} />
+        <PageviewsChart range={range} />
+        <MetricsGrid range={range} />
+        <UptimeSection />
+      </PageContent>
     </Layout>
   );
 }

--- a/src/pages/insights/styles.module.css
+++ b/src/pages/insights/styles.module.css
@@ -1,8 +1,4 @@
-.container {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 3vw, 2rem);
+.layout {
   display: flex;
   flex-direction: column;
   gap: clamp(2rem, 4vw, 3rem);
@@ -13,52 +9,10 @@
   justify-content: flex-end;
 }
 
-.rangeTabs {
-  display: inline-flex;
-  gap: 0.25rem;
-  padding: 0.3rem;
-  background: var(--ifm-color-emphasis-100);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 14px;
-}
-
-html[data-theme='dark'] .rangeTabs {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-.rangeTab {
-  appearance: none;
-  border: none;
-  background: transparent;
-  padding: 0.5rem 1rem;
-  border-radius: 10px;
-  font-weight: 600;
-  font-size: 0.88rem;
-  color: var(--ifm-color-emphasis-700);
-  cursor: pointer;
-  transition: color 200ms ease;
-}
-
-.rangeTab:hover {
-  color: var(--ifm-color-emphasis-900);
-}
-
-.rangeTabActive,
-.rangeTabActive:hover {
-  background: var(--ifm-card-background-color);
-  color: var(--ifm-color-primary);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.04),
-    0 4px 12px rgba(0, 0, 0, 0.06);
-}
-
-html[data-theme='dark'] .rangeTabActive,
-html[data-theme='dark'] .rangeTabActive:hover {
-  background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-primary-light);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.3),
-    0 4px 12px rgba(0, 0, 0, 0.25);
+@media (max-width: 480px) {
+  .rangeBar {
+    width: 100%;
+  }
 }
 
 .heroGrid {
@@ -82,7 +36,7 @@ html[data-theme='dark'] .rangeTabActive:hover {
 }
 
 .heroValue {
-  font-size: clamp(1.75rem, 2vw + 0.6rem, 2.5rem);
+  font-size: clamp(1.35rem, 1.2vw + 0.6rem, 1.85rem);
   font-weight: 700;
   letter-spacing: -0.02em;
   line-height: 1.05;
@@ -123,26 +77,10 @@ html[data-theme='dark'] .heroDeltaDown {
 }
 
 .skeletonText {
+  composes: skeleton from '../../components/laikit/Skeleton/styles.module.css';
   position: relative;
   color: transparent;
   border-radius: 8px;
-  background: linear-gradient(
-    90deg,
-    var(--ifm-color-emphasis-100) 0%,
-    var(--ifm-color-emphasis-200) 50%,
-    var(--ifm-color-emphasis-100) 100%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
 }
 
 @media (max-width: 480px) {
@@ -151,30 +89,24 @@ html[data-theme='dark'] .heroDeltaDown {
   }
 }
 
-.sectionTitle {
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  margin: 0;
-  color: var(--ifm-font-color-base);
+@media (max-width: 360px) {
+  .heroGrid {
+    grid-template-columns: 1fr;
+  }
 }
 
-.chartSection {
+.chartCard {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.chartHead {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  margin-top: calc(1rem - clamp(2rem, 4vw, 3rem));
 }
 
 .metricsGrid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
+  margin-top: calc(1rem - clamp(2rem, 4vw, 3rem));
 }
 
 @media (max-width: 640px) {

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -2,7 +2,11 @@ import React, { type ReactNode, useState, useMemo } from 'react';
 import { Icon } from '@iconify/react';
 import Layout from '@theme/Layout';
 
-import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  PageTitle,
+  PageHeader,
+  PageContent,
+} from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import LinkCard from '@site/src/components/laikit/LinkCard';
 import IconText from '@site/src/components/laikit/IconText';
@@ -207,7 +211,7 @@ function ResourcesMain() {
   }, [activeCategory, searchQuery]);
 
   return (
-    <div className={styles.container}>
+    <PageContent className={styles.layout}>
       <SearchBar value={searchQuery} onChange={setSearchQuery} />
 
       <CategoryNav
@@ -239,7 +243,7 @@ function ResourcesMain() {
           </Button>
         </div>
       )}
-    </div>
+    </PageContent>
   );
 }
 

--- a/src/pages/resources/styles.module.css
+++ b/src/pages/resources/styles.module.css
@@ -1,25 +1,9 @@
 /* Layout */
 
-.container {
-  width: 100%;
-  max-width: 1200px;
-  margin: auto;
-  padding: 2rem;
+.layout {
   display: flex;
   flex-direction: column;
   gap: 2rem;
-}
-
-@media (max-width: 1199px) {
-  .container {
-    padding: 1.5rem;
-  }
-}
-
-@media (max-width: 768px) {
-  .container {
-    padding: 1rem;
-  }
 }
 
 /* Search & category nav */

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -22,7 +22,11 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { usePersistentState } from '@site/src/hooks/usePersistentState';
 import { useThemeColors } from '@site/src/hooks/useThemeColors';
 import { Icon } from '@iconify/react';
-import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  PageTitle,
+  PageHeader,
+  PageContent,
+} from '@site/src/components/laikit/Page';
 import styles from './styles.module.css';
 
 const TITLE = translate({
@@ -489,14 +493,14 @@ function LanguageSettings() {
 
 function SettingsContainer() {
   return (
-    <div className={styles.container}>
+    <PageContent className={styles.layout}>
       <ThemeSettings />
       <LanguageSettings />
       <AccentColor />
       <Typography />
       <ExperimentalFeatures />
       <QuickActions />
-    </div>
+    </PageContent>
   );
 }
 

--- a/src/pages/settings/styles.module.css
+++ b/src/pages/settings/styles.module.css
@@ -11,52 +11,44 @@
   }
 }
 
-.container {
+.layout {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-template-areas: 'a1 a2 a3' 'a4 a5 a6';
   gap: 1.5rem;
-
-  width: 100%;
-  max-width: 1200px;
-  margin: auto;
-  padding: 2rem 2rem 4rem;
-
   animation: fadeIn 0.3s ease-out;
 }
 
 @media (max-width: 1199px) {
-  .container {
+  .layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas: 'a1 a4' 'a2 a3' 'a5 a6';
-    padding: 1.5rem;
   }
 }
 
 @media (max-width: 768px) {
-  .container {
+  .layout {
     grid-template-columns: 1fr;
     grid-template-areas: 'a1' 'a2' 'a3' 'a4' 'a5' 'a6';
-    padding: 1rem;
   }
 }
 
-.container > :nth-child(1) {
+.layout > :nth-child(1) {
   grid-area: a1;
 }
-.container > :nth-child(2) {
+.layout > :nth-child(2) {
   grid-area: a2;
 }
-.container > :nth-child(3) {
+.layout > :nth-child(3) {
   grid-area: a3;
 }
-.container > :nth-child(4) {
+.layout > :nth-child(4) {
   grid-area: a4;
 }
-.container > :nth-child(5) {
+.layout > :nth-child(5) {
   grid-area: a5;
 }
-.container > :nth-child(6) {
+.layout > :nth-child(6) {
   grid-area: a6;
 }
 

--- a/src/pages/travel/index.tsx
+++ b/src/pages/travel/index.tsx
@@ -1,6 +1,10 @@
 import React, { type ReactNode } from 'react';
 import Layout from '@theme/Layout';
-import { PageTitle, PageHeader } from '@site/src/components/laikit/Page';
+import {
+  PageTitle,
+  PageHeader,
+  PageContent,
+} from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import TravelTimeline from '@site/src/pages/travel/_components/Timeline';
 import TravelMap from '@site/src/pages/travel/_components/Map';
@@ -57,8 +61,10 @@ export default function Travel(): ReactNode {
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
       <TravelHeader />
-      <TravelMap />
-      <TravelTimeline />
+      <PageContent>
+        <TravelMap />
+        <TravelTimeline />
+      </PageContent>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary

- Heavy iteration on the **Insights** page: better chart, real rolling 24h window, weekly aggregation for 1 year, range selector lifted into `<PageHeader>`, no layout jump on load.
- Two new **laikit primitives** extracted from page-level dupes:
  - `laikit/Skeleton` — shared shimmer base, used via CSS `composes:` from 4 places
  - `laikit/Page → PageContent` — shared `<main>` wrapper (max-width 1200px + responsive padding); migrated `insights / resources / friends / settings / travel`

## Insights page changes

**Range selector**
- Replaced inline `RangeBar` with `laikit/Segmented` (new `orientation="horizontal"` prop, default vertical preserves settings page)
- Moved into `<PageHeader>` (right side desktop, stacked mobile)
- Responsive: stacks vertical and full-width on ≤480px
- New tab order: **24 hours / 7 days / 30 days / 1 year**, default = 24 hours

**Bucketing & data**
- 24 hours: hourly buckets, `endAt` rounded up to next hour so current bucket is included → real rolling window
- 7 days: hourly fetch, downsampled to **6h windows** (28 points)
- 30 days: daily
- 1 year: chunked into 2 fetches (Umami caps `unit=day` at ~200 days), then aggregated by **Monday-aligned weeks**
- Zero-fill missing buckets (Umami omits buckets with 0 pageviews) using request-aligned grid, so empty hours/days/weeks show as 0 instead of being interpolated over

**Chart (`Sparkline`)**
- Card now matches list cards: `lucide:line-chart` icon + small title header
- Dashed gridlines, X-axis date ticks, hover crosshair + tooltip with **date range** sized to bucket (`May 1, 14:00 – 15:00` / `Apr 25 – May 4, 2025`)
- Removed pulse breath dot
- Fixed line-draw animation for long paths via `pathLength={1}` (was clipped at dasharray 3000)
- Loading state renders same wrapper structure with placeholder X-axis → no 24px height jump on load
- i18n: dates render in current Docusaurus locale (en / zh)

**Hero metrics**
- Smaller value font (`clamp(1.35rem, 1.2vw + 0.6rem, 1.85rem)`)
- Wider skeleton placeholder + reserved delta line during loading → no vertical jump

**Top lists (`MetricList`)**
- Country flags: Umami CDN PNG instead of emoji
- Hover gray layer aligned with bar geometry (`inset: 4px 0`, radius 8px)
- Label font-weight 500
- Skeleton: 8 rows × 42px (was 5 × 32px) → matches loaded list height
- Removed Devices card

**System status**
- Reordered to bottom of page (consistent with `Live Insights` / `Live numbers` page semantics)
- Card paddings unified across page (`1.5rem 1.25rem 1.25rem`)

## New laikit primitives

**`laikit/Skeleton`**
- Component + CSS class with shared `linear-gradient` + `shimmer` keyframes
- 4 consumer CSS modules now use `composes: skeleton from '...'` instead of duplicating ~15 lines each (~60 lines saved)

**`laikit/Page → PageContent`**
- Polymorphic wrapper (`as` prop, defaults to `<main>`)
- Provides `width: 100% / max-width: 1200px / margin: 0 auto / padding: clamp(2rem, 4vw, 3rem) clamp(1rem, 3vw, 2rem)`
- Migrated `insights / resources / friends / settings / travel`; each page's `.layout` now contains only display/gap/grid-template — no more duplicated max-width/margin/padding boilerplate

## Test plan

- [ ] `/insights` — switch ranges (24h / 7d / 30d / 1y), verify chart point counts (24 / 28 / 30 / 36+) and tooltip date ranges
- [ ] `/insights` — refresh during loading: no card height jump
- [ ] `/insights` mobile (≤480px): range selector stacks vertical full-width; hero grid 2 cols (1 col at ≤360px)
- [ ] `/insights` zh-Hans: dates render in Chinese locale
- [ ] `/resources`, `/friends`, `/settings`, `/travel` — visual sanity check after PageContent migration
- [ ] System status: production deploy at `lailai.one` should show monitor list (CORS allows `https://lailai.one` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)