### PR TITLE
Polish insights page and unify color/tooltip primitives

### DIFF
--- a/src/components/laikit/Button/styles.module.css
+++ b/src/components/laikit/Button/styles.module.css
@@ -20,7 +20,7 @@
 
 .button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px rgba(var(--ifm-color-primary-rgb), 0.24);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ifm-color-primary) 24%, transparent);
 }
 
 .button:disabled,

--- a/src/components/laikit/Card/styles.module.css
+++ b/src/components/laikit/Card/styles.module.css
@@ -8,7 +8,6 @@
 
 .linkCard {
   --link-card-accent: var(--ifm-color-primary);
-  --link-card-accent-rgb: var(--ifm-color-primary-rgb);
   display: block;
   color: inherit;
   text-decoration: none;
@@ -36,12 +35,12 @@
 
 .linkCard:focus-visible .card {
   box-shadow:
-    0 0 0 3px rgba(var(--link-card-accent-rgb), 0.18),
+    0 0 0 3px color-mix(in srgb, var(--link-card-accent) 18%, transparent),
     0 6px 16px rgba(0, 0, 0, 0.06);
 }
 
 html[data-theme='dark'] .linkCard:focus-visible .card {
   box-shadow:
-    0 0 0 3px rgba(var(--link-card-accent-rgb), 0.24),
+    0 0 0 3px color-mix(in srgb, var(--link-card-accent) 24%, transparent),
     0 6px 16px rgba(0, 0, 0, 0.06);
 }

--- a/src/components/laikit/IconBlock/styles.module.css
+++ b/src/components/laikit/IconBlock/styles.module.css
@@ -14,21 +14,21 @@
 .accent {
   background: linear-gradient(
     135deg,
-    rgba(var(--ifm-color-primary-rgb), 0.16),
-    rgba(var(--ifm-color-primary-rgb), 0.08)
+    color-mix(in srgb, var(--ifm-color-primary) 16%, transparent),
+    color-mix(in srgb, var(--ifm-color-primary) 8%, transparent)
   );
   color: var(--ifm-color-primary);
-  border: 1px solid rgba(var(--ifm-color-primary-rgb), 0.18);
+  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
 }
 
 html[data-theme='dark'] .accent {
   background: linear-gradient(
     135deg,
-    rgba(var(--ifm-color-primary-rgb), 0.22),
-    rgba(var(--ifm-color-primary-rgb), 0.1)
+    color-mix(in srgb, var(--ifm-color-primary) 22%, transparent),
+    color-mix(in srgb, var(--ifm-color-primary) 10%, transparent)
   );
   color: var(--ifm-color-primary-light);
-  border-color: rgba(var(--ifm-color-primary-rgb), 0.28);
+  border-color: color-mix(in srgb, var(--ifm-color-primary) 28%, transparent);
 }
 
 /* Neutral variant for stat/metric icons. */

--- a/src/components/laikit/Page/styles.module.css
+++ b/src/components/laikit/Page/styles.module.css
@@ -51,3 +51,12 @@
     align-items: flex-start;
   }
 }
+
+@media (max-width: 360px) {
+  .mainTitle {
+    font-size: clamp(1.4rem, 6vw, 1.8rem);
+  }
+  .mainDescription {
+    font-size: 0.92rem;
+  }
+}

--- a/src/components/laikit/Segmented/styles.module.css
+++ b/src/components/laikit/Segmented/styles.module.css
@@ -76,7 +76,7 @@ html[data-theme='dark'] .item:hover {
 }
 
 .item:focus-visible {
-  box-shadow: 0 0 0 2px rgba(var(--ifm-color-primary-rgb), 0.4);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
 }
 
 .itemActive,

--- a/src/components/laikit/Tooltip/index.tsx
+++ b/src/components/laikit/Tooltip/index.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+export interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  leftPct?: number;
+}
+
+function Tooltip({
+  leftPct,
+  className,
+  style,
+  children,
+  ...rest
+}: TooltipProps) {
+  const finalStyle =
+    leftPct != null ? { ...style, left: `${leftPct}%` } : style;
+  return (
+    <div
+      {...rest}
+      className={clsx(styles.tooltip, className)}
+      style={finalStyle}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TooltipLabel({
+  className,
+  ...rest
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span {...rest} className={clsx(styles.label, className)} />;
+}
+
+function TooltipValue({
+  className,
+  ...rest
+}: React.HTMLAttributes<HTMLSpanElement>) {
+  return <span {...rest} className={clsx(styles.value, className)} />;
+}
+
+Tooltip.Label = TooltipLabel;
+Tooltip.Value = TooltipValue;
+
+export default Tooltip;

--- a/src/components/laikit/Tooltip/styles.module.css
+++ b/src/components/laikit/Tooltip/styles.module.css
@@ -1,0 +1,40 @@
+.tooltip {
+  position: absolute;
+  top: -8px;
+  transform: translate(-50%, -100%);
+  background: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 8px;
+  padding: 0.4rem 0.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  white-space: nowrap;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.06),
+    0 8px 24px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  z-index: 2;
+}
+
+html[data-theme='dark'] .tooltip {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px rgba(0, 0, 0, 0.35);
+}
+
+.label {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  letter-spacing: 0.02em;
+}
+
+.value {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ifm-font-color-base);
+  font-variant-numeric: tabular-nums;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -17,10 +17,20 @@
 
   --global-font-size: 16px;
   --global-line-height: 1.65;
+
+  --lk-color-up: #1a8754;
+  --lk-color-down: #d93838;
+  --lk-color-pending: #f0a52a;
+  --lk-color-maintenance: #5a8dee;
 }
 
 [data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+
+  --lk-color-up: #34c77b;
+  --lk-color-down: #ff6b6b;
+  --lk-color-pending: #ffb84a;
+  --lk-color-maintenance: #7aa6ff;
 }
 
 .header-github-link::before {

--- a/src/pages/_components/Bento/styles.module.css
+++ b/src/pages/_components/Bento/styles.module.css
@@ -159,8 +159,8 @@
   border-radius: 20px;
   background: linear-gradient(
     135deg,
-    rgba(var(--link-card-accent-rgb), 0.1),
-    rgba(var(--link-card-accent-rgb), 0.05)
+    color-mix(in srgb, var(--link-card-accent) 10%, transparent),
+    color-mix(in srgb, var(--link-card-accent) 5%, transparent)
   );
 }
 
@@ -327,7 +327,7 @@
 .statusDot {
   width: 8px;
   height: 8px;
-  background: #22c55e;
+  background: var(--lk-color-up);
   border-radius: 50%;
   animation: pulse 2s ease-in-out infinite;
 }

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -17,7 +17,7 @@
   /* Aligned with Lorenz Attractor's blue/orange trail palette. */
   --nn-connection-negative-rgb: 249, 115, 22;
   --nn-connection-positive-rgb: 29, 155, 240;
-  --nn-connection-animation: rgba(var(--ifm-color-primary-rgb), 0.55);
+  --nn-connection-animation: color-mix(in srgb, var(--ifm-color-primary) 55%, transparent);
   --nn-connection-default: #666666;
 
   --nn-grid-white: #ffffff;
@@ -54,7 +54,7 @@
   --nn-neuron-gray-base: 255;
   --nn-neuron-gray-multiplier: -255;
 
-  --nn-connection-animation: rgba(var(--ifm-color-primary-rgb), 0.7);
+  --nn-connection-animation: color-mix(in srgb, var(--ifm-color-primary) 70%, transparent);
   --nn-connection-default: #c7d2fe;
 
   --nn-grid-white: #000000;

--- a/src/pages/insights/_components/HeartbeatBar.module.css
+++ b/src/pages/insights/_components/HeartbeatBar.module.css
@@ -1,57 +1,63 @@
+.wrap {
+  position: relative;
+  width: 100%;
+}
+
 .bar {
   display: flex;
   gap: 2px;
-  height: 28px;
+  height: 16px;
   width: 100%;
 }
 
 .cell {
   flex: 1;
-  min-width: 3px;
-  border-radius: 3px;
+  min-width: 2px;
+  border-radius: 2px;
   transition:
     transform 160ms ease,
     opacity 160ms ease;
-  cursor: help;
 }
 
 .cell:hover {
-  transform: scaleY(1.15);
+  transform: scaleY(1.1);
 }
 
 .up {
-  background: #1a8754;
+  background: var(--lk-color-up);
 }
 
 .down {
-  background: #d93838;
+  background: var(--lk-color-down);
 }
 
 .pending {
-  background: #f0a52a;
+  background: var(--lk-color-pending);
 }
 
 .maintenance {
-  background: #5a8dee;
+  background: var(--lk-color-maintenance);
 }
 
 .empty {
   background: var(--ifm-color-emphasis-200);
-  cursor: default;
 }
 
-html[data-theme='dark'] .up {
-  background: #34c77b;
+.tooltipPing {
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-600);
 }
 
-html[data-theme='dark'] .down {
-  background: #ff6b6b;
+.tooltipMsg {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  max-width: 280px;
+  white-space: normal;
 }
 
-html[data-theme='dark'] .pending {
-  background: #ffb84a;
-}
-
-html[data-theme='dark'] .maintenance {
-  background: #7aa6ff;
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
 }

--- a/src/pages/insights/_components/HeartbeatBar.tsx
+++ b/src/pages/insights/_components/HeartbeatBar.tsx
@@ -1,10 +1,38 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { translate } from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type { KumaHeartbeat } from '@site/src/utils/kuma';
+import Tooltip from '@site/src/components/laikit/Tooltip';
 import styles from './HeartbeatBar.module.css';
 
 interface HeartbeatBarProps {
   beats: KumaHeartbeat[];
   slots?: number;
+}
+
+const CELL_MIN = 2;
+const GAP = 2;
+
+function useResponsiveSlots(maxSlots: number) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [slots, setSlots] = useState(maxSlots);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0].contentRect.width;
+      const fit = Math.max(
+        1,
+        Math.min(maxSlots, Math.floor((w + GAP) / (CELL_MIN + GAP)))
+      );
+      setSlots(fit);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [maxSlots]);
+
+  return [ref, slots] as const;
 }
 
 function statusClass(status: number | undefined): string {
@@ -22,40 +50,120 @@ function statusClass(status: number | undefined): string {
   }
 }
 
-function formatTime(iso: string): string {
-  try {
-    return new Date(iso).toLocaleString();
-  } catch {
-    return iso;
+function statusLabel(status: number | undefined): string {
+  switch (status) {
+    case 1:
+      return translate({
+        id: 'pages.insights.heartbeat.up',
+        message: 'Up',
+      });
+    case 0:
+      return translate({
+        id: 'pages.insights.heartbeat.down',
+        message: 'Down',
+      });
+    case 2:
+      return translate({
+        id: 'pages.insights.heartbeat.pending',
+        message: 'Pending',
+      });
+    case 3:
+      return translate({
+        id: 'pages.insights.heartbeat.maintenance',
+        message: 'Maintenance',
+      });
+    default:
+      return translate({
+        id: 'pages.insights.heartbeat.unknown',
+        message: 'No data',
+      });
   }
 }
 
-export default function HeartbeatBar({ beats, slots = 60 }: HeartbeatBarProps) {
+function parseDate(iso: string): Date {
+  return new Date(iso.replace(' ', 'T'));
+}
+
+function formatTooltipDate(iso: string, locale: string): string {
+  const d = parseDate(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(locale, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  });
+}
+
+export default function HeartbeatBar({ beats, slots = 100 }: HeartbeatBarProps) {
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [wrapRef, fitSlots] = useResponsiveSlots(slots);
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext();
+  const locale = currentLocale === 'zh-Hans' ? 'zh' : 'en';
+
+  const effectiveSlots = Math.min(slots, fitSlots);
+
   const padded: (KumaHeartbeat | null)[] = [];
-  const start = Math.max(0, beats.length - slots);
+  const start = Math.max(0, beats.length - effectiveSlots);
   const recent = beats.slice(start);
-  const empty = slots - recent.length;
+  const empty = effectiveSlots - recent.length;
   for (let i = 0; i < empty; i++) padded.push(null);
   for (const b of recent) padded.push(b);
 
+  const active = hoverIdx != null ? padded[hoverIdx] : null;
+  const tooltipLeftPct =
+    hoverIdx != null ? ((hoverIdx + 0.5) / effectiveSlots) * 100 : 0;
+
   return (
-    <div className={styles.bar} role="img" aria-label="Recent heartbeat status">
-      {padded.map((beat, i) => {
-        if (!beat) {
-          return <span key={i} className={`${styles.cell} ${styles.empty}`} />;
-        }
-        const tooltip =
-          `${formatTime(beat.time)}` +
-          (typeof beat.ping === 'number' ? ` · ${beat.ping}ms` : '') +
-          (beat.msg ? ` · ${beat.msg}` : '');
-        return (
+    <div className={styles.wrap} ref={wrapRef}>
+      <div
+        className={styles.bar}
+        role="img"
+        aria-label="Recent heartbeat status"
+        onPointerLeave={() => setHoverIdx(null)}
+      >
+        {padded.map((beat, i) => (
           <span
             key={i}
-            className={`${styles.cell} ${statusClass(beat.status)}`}
-            title={tooltip}
+            className={`${styles.cell} ${
+              beat ? statusClass(beat.status) : styles.empty
+            }`}
+            onPointerEnter={() => setHoverIdx(i)}
           />
-        );
-      })}
+        ))}
+      </div>
+
+      {hoverIdx != null && (
+        <Tooltip leftPct={tooltipLeftPct}>
+          <Tooltip.Label>
+            {active
+              ? formatTooltipDate(active.time, locale)
+              : translate({
+                  id: 'pages.insights.heartbeat.noData',
+                  message: 'No data',
+                })}
+          </Tooltip.Label>
+          <Tooltip.Value>
+            <span
+              className={`${styles.dot} ${
+                active ? statusClass(active.status) : styles.empty
+              }`}
+              aria-hidden="true"
+            />
+            {statusLabel(active?.status)}
+            {active && typeof active.ping === 'number' && (
+              <span className={styles.tooltipPing}>· {active.ping}ms</span>
+            )}
+          </Tooltip.Value>
+          {active?.msg && (
+            <span className={styles.tooltipMsg}>{active.msg}</span>
+          )}
+        </Tooltip>
+      )}
     </div>
   );
 }

--- a/src/pages/insights/_components/MetricList.module.css
+++ b/src/pages/insights/_components/MetricList.module.css
@@ -3,6 +3,8 @@
   flex-direction: column;
   gap: 1rem;
   min-height: 320px;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .head {
@@ -45,6 +47,20 @@
   align-items: center;
   padding: 0.55rem 0.75rem;
   font-size: 0.92rem;
+  min-width: 0;
+}
+
+@media (max-width: 360px) {
+  .row {
+    padding: 0.5rem 0.5rem;
+    font-size: 0.85rem;
+  }
+}
+
+@media (max-width: 360px) {
+  .card {
+    --card-padding: 1.1rem 0.7rem 0.7rem !important;
+  }
 }
 
 .row::before {
@@ -64,7 +80,7 @@
 .bar {
   position: absolute;
   inset: 4px auto 4px 0;
-  background: rgba(var(--ifm-color-primary-rgb), 0.08);
+  background: color-mix(in srgb, var(--ifm-color-primary) 8%, transparent);
   border-radius: 8px;
   pointer-events: none;
   transition: width 600ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/pages/insights/_components/Sparkline.module.css
+++ b/src/pages/insights/_components/Sparkline.module.css
@@ -51,44 +51,6 @@ html[data-theme='dark'] .grid {
   pointer-events: none;
 }
 
-.tooltip {
-  position: absolute;
-  top: -8px;
-  transform: translate(-50%, -100%);
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  border-radius: 8px;
-  padding: 0.4rem 0.65rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.1rem;
-  white-space: nowrap;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.06),
-    0 8px 24px rgba(0, 0, 0, 0.08);
-  pointer-events: none;
-  z-index: 2;
-}
-
-html[data-theme='dark'] .tooltip {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 8px 24px rgba(0, 0, 0, 0.35);
-}
-
-.tooltipDate {
-  font-size: 0.72rem;
-  color: var(--ifm-color-emphasis-600);
-  letter-spacing: 0.02em;
-}
-
-.tooltipValue {
-  font-size: 0.95rem;
-  font-weight: 700;
-  color: var(--ifm-font-color-base);
-  font-variant-numeric: tabular-nums;
-}
-
 .xAxis {
   position: relative;
   width: 100%;

--- a/src/pages/insights/_components/Sparkline.tsx
+++ b/src/pages/insights/_components/Sparkline.tsx
@@ -1,6 +1,7 @@
 import React, { useId, useMemo, useRef, useState } from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import type { SeriesPoint } from '@site/src/hooks/useUmamiPageviewsSeries';
+import Tooltip from '@site/src/components/laikit/Tooltip';
 import styles from './Sparkline.module.css';
 
 type SparklineUnit = 'hour' | '6h' | 'day' | 'week';
@@ -124,8 +125,8 @@ function formatTooltipDate(
   return formatYMD(d, locale);
 }
 
-function formatCompact(n: number): string {
-  return new Intl.NumberFormat('en', {
+function formatCompact(n: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
     notation: 'compact',
     maximumFractionDigits: 1,
   }).format(n);
@@ -295,17 +296,14 @@ export default function Sparkline({
         </svg>
 
         {hoverIdx !== null && (
-          <div
-            className={styles.tooltip}
-            style={{ left: `${tooltipLeftPct}%` }}
-          >
-            <span className={styles.tooltipDate}>
+          <Tooltip leftPct={tooltipLeftPct}>
+            <Tooltip.Label>
               {formatTooltipDate(data[activeIdx].x, unit, locale)}
-            </span>
-            <span className={styles.tooltipValue}>
-              {formatCompact(values[activeIdx])}
-            </span>
-          </div>
+            </Tooltip.Label>
+            <Tooltip.Value>
+              {formatCompact(values[activeIdx], locale)}
+            </Tooltip.Value>
+          </Tooltip>
         )}
       </div>
 

--- a/src/pages/insights/_components/UptimeSection.module.css
+++ b/src/pages/insights/_components/UptimeSection.module.css
@@ -2,85 +2,27 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  margin-top: calc(1rem - clamp(2rem, 4vw, 3rem));
 }
 
-.head {
+.statePanel {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  flex-wrap: wrap;
+  gap: 0.75rem;
+  text-align: center;
 }
 
-.title {
-  font-size: 1.05rem;
-  font-weight: 600;
-  letter-spacing: -0.01em;
+.stateIcon {
+  font-size: 1.6rem;
+  color: var(--lk-color-down);
+}
+
+.stateText {
   margin: 0;
-  color: var(--ifm-font-color-base);
-}
-
-.pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  border: 1px solid transparent;
-}
-
-.pillUp {
-  background: rgba(26, 135, 84, 0.1);
-  color: #1a8754;
-  border-color: rgba(26, 135, 84, 0.25);
-}
-
-.pillDown {
-  background: rgba(217, 56, 56, 0.1);
-  color: #d93838;
-  border-color: rgba(217, 56, 56, 0.25);
-}
-
-.pillMaintenance {
-  background: rgba(90, 141, 238, 0.1);
-  color: #5a8dee;
-  border-color: rgba(90, 141, 238, 0.25);
-}
-
-.pillEmpty {
-  background: var(--ifm-color-emphasis-100);
+  font-size: 0.95rem;
+  font-weight: 500;
   color: var(--ifm-color-emphasis-700);
-  border-color: var(--ifm-color-emphasis-200);
-}
-
-html[data-theme='dark'] .pillUp {
-  background: rgba(52, 199, 123, 0.16);
-  color: #34c77b;
-  border-color: rgba(52, 199, 123, 0.32);
-}
-
-html[data-theme='dark'] .pillDown {
-  background: rgba(255, 107, 107, 0.16);
-  color: #ff6b6b;
-  border-color: rgba(255, 107, 107, 0.32);
-}
-
-html[data-theme='dark'] .pillMaintenance {
-  background: rgba(122, 166, 255, 0.16);
-  color: #7aa6ff;
-  border-color: rgba(122, 166, 255, 0.32);
-}
-
-.spin {
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .list {
@@ -99,6 +41,12 @@ html[data-theme='dark'] .pillMaintenance {
   display: flex;
   align-items: center;
   gap: 0.65rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.row {
+  min-width: 0;
 }
 
 .dot {
@@ -110,23 +58,23 @@ html[data-theme='dark'] .pillMaintenance {
 }
 
 .dotUp {
-  background: #1a8754;
-  box-shadow: 0 0 0 4px rgba(26, 135, 84, 0.18);
+  background: var(--lk-color-up);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-up) 18%, transparent);
 }
 
 .dotDown {
-  background: #d93838;
-  box-shadow: 0 0 0 4px rgba(217, 56, 56, 0.2);
+  background: var(--lk-color-down);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-down) 20%, transparent);
 }
 
 .dotPending {
-  background: #f0a52a;
-  box-shadow: 0 0 0 4px rgba(240, 165, 42, 0.2);
+  background: var(--lk-color-pending);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-pending) 20%, transparent);
 }
 
 .dotMaintenance {
-  background: #5a8dee;
-  box-shadow: 0 0 0 4px rgba(90, 141, 238, 0.2);
+  background: var(--lk-color-maintenance);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-maintenance) 20%, transparent);
 }
 
 .dotEmpty {
@@ -134,17 +82,23 @@ html[data-theme='dark'] .pillMaintenance {
 }
 
 html[data-theme='dark'] .dotUp {
-  background: #34c77b;
-  box-shadow: 0 0 0 4px rgba(52, 199, 123, 0.22);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-up) 22%, transparent);
 }
 
 html[data-theme='dark'] .dotDown {
-  background: #ff6b6b;
-  box-shadow: 0 0 0 4px rgba(255, 107, 107, 0.22);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-down) 22%, transparent);
+}
+
+.nameWrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  min-height: 1.5em;
 }
 
 .name {
-  flex: 1;
+  max-width: 100%;
   font-weight: 600;
   color: var(--ifm-color-emphasis-900);
   white-space: nowrap;

--- a/src/pages/insights/_components/UptimeSection.tsx
+++ b/src/pages/insights/_components/UptimeSection.tsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import { Icon } from '@iconify/react';
+import Link from '@docusaurus/Link';
 import { translate } from '@docusaurus/Translate';
 import Card from '@site/src/components/laikit/Card';
 import { useKumaStatus } from '@site/src/hooks/useKumaStatus';
 import type { KumaHeartbeat, KumaMonitor } from '@site/src/utils/kuma';
 import HeartbeatBar from './HeartbeatBar';
 import styles from './UptimeSection.module.css';
-
-type OverallStatus =
-  | 'operational'
-  | 'degraded'
-  | 'major'
-  | 'maintenance'
-  | 'unknown';
 
 function lastStatus(beats: KumaHeartbeat[] | undefined): number | undefined {
   if (!beats || beats.length === 0) return undefined;
@@ -29,76 +23,6 @@ function avgPing(beats: KumaHeartbeat[] | undefined): number | null {
     valid.reduce((s, b) => s + (b.ping ?? 0), 0) / valid.length
   );
 }
-
-function overall(
-  monitors: KumaMonitor[],
-  beats: Record<string, KumaHeartbeat[]>
-): OverallStatus {
-  if (monitors.length === 0) return 'unknown';
-  let down = 0;
-  let pending = 0;
-  let maintenance = 0;
-  let up = 0;
-  for (const m of monitors) {
-    const s = lastStatus(beats[String(m.id)]);
-    if (s === 1) up++;
-    else if (s === 0) down++;
-    else if (s === 2) pending++;
-    else if (s === 3) maintenance++;
-  }
-  if (down >= monitors.length) return 'major';
-  if (down > 0) return 'degraded';
-  if (maintenance > 0) return 'maintenance';
-  if (up > 0) return 'operational';
-  if (pending > 0) return 'unknown';
-  return 'unknown';
-}
-
-const STATUS_COPY: Record<
-  OverallStatus,
-  { label: string; icon: string; cls: string }
-> = {
-  operational: {
-    label: translate({
-      id: 'pages.insights.status.operational',
-      message: 'All systems operational',
-    }),
-    icon: 'lucide:check-circle-2',
-    cls: 'pillUp',
-  },
-  degraded: {
-    label: translate({
-      id: 'pages.insights.status.degraded',
-      message: 'Partial outage',
-    }),
-    icon: 'lucide:alert-triangle',
-    cls: 'pillDown',
-  },
-  major: {
-    label: translate({
-      id: 'pages.insights.status.major',
-      message: 'Major outage',
-    }),
-    icon: 'lucide:x-circle',
-    cls: 'pillDown',
-  },
-  maintenance: {
-    label: translate({
-      id: 'pages.insights.status.maintenance',
-      message: 'Under maintenance',
-    }),
-    icon: 'lucide:wrench',
-    cls: 'pillMaintenance',
-  },
-  unknown: {
-    label: translate({
-      id: 'pages.insights.status.unknown',
-      message: 'Status unknown',
-    }),
-    icon: 'lucide:help-circle',
-    cls: 'pillEmpty',
-  },
-};
 
 function MonitorRow({
   monitor,
@@ -129,40 +53,31 @@ function MonitorRow({
     <Card padding="1.1rem 1.25rem" className={styles.row}>
       <div className={styles.rowHead}>
         <span className={`${styles.dot} ${statusCls}`} aria-hidden="true" />
-        <span className={styles.name}>{monitor.name}</span>
+        <div className={styles.nameWrap}>
+          {monitor.url ? (
+            <Link className={styles.name} href={monitor.url}>
+              {monitor.name}
+            </Link>
+          ) : (
+            <span className={styles.name}>{monitor.name}</span>
+          )}
+        </div>
         <span className={styles.uptime}>
           <span className={styles.uptimeValue}>{upPct}%</span>
-          <span className={styles.uptimeLabel}>
-            {translate({
-              id: 'pages.insights.uptime.last24h',
-              message: '24h uptime',
-            })}
-          </span>
-        </span>
-      </div>
-      <HeartbeatBar beats={beats ?? []} slots={60} />
-      <div className={styles.rowFoot}>
-        <span>
-          {translate(
-            {
-              id: 'pages.insights.uptime.checks',
-              message: '{count} recent checks',
-            },
-            { count: beats?.length ?? 0 }
+          {ping != null && (
+            <span className={styles.uptimeLabel}>
+              {translate(
+                {
+                  id: 'pages.insights.uptime.avgPing',
+                  message: 'Avg {ping}ms',
+                },
+                { ping }
+              )}
+            </span>
           )}
         </span>
-        {ping != null && (
-          <span>
-            {translate(
-              {
-                id: 'pages.insights.uptime.avgPing',
-                message: 'Avg {ping}ms',
-              },
-              { ping }
-            )}
-          </span>
-        )}
       </div>
+      <HeartbeatBar beats={beats ?? []} slots={100} />
     </Card>
   );
 }
@@ -178,54 +93,19 @@ export default function UptimeSection() {
   const heartbeats = data?.heartbeats.heartbeatList ?? {};
   const uptimes = data?.heartbeats.uptimeList ?? {};
 
-  const ovStatus = overall(monitors, heartbeats);
-  const ovCopy = STATUS_COPY[ovStatus];
-
   return (
     <section className={styles.section}>
-      <header className={styles.head}>
-        <h2 className={styles.title}>
-          {translate({
-            id: 'pages.insights.uptime.title',
-            message: 'System status',
-          })}
-        </h2>
-        <span
-          className={`${styles.pill} ${
-            loading
-              ? styles.pillEmpty
-              : errored
-                ? styles.pillDown
-                : (styles as Record<string, string>)[ovCopy.cls]
-          }`}
-        >
-          <Icon
-            icon={
-              loading
-                ? 'lucide:loader-2'
-                : errored
-                  ? 'lucide:cloud-off'
-                  : ovCopy.icon
-            }
-            className={loading ? styles.spin : undefined}
-          />
-          <span>
-            {loading
-              ? translate({
-                  id: 'pages.insights.status.loading',
-                  message: 'Checking…',
-                })
-              : errored
-                ? translate({
-                    id: 'pages.insights.status.error',
-                    message: 'Unable to reach status server',
-                  })
-                : ovCopy.label}
-          </span>
-        </span>
-      </header>
-
-      {!errored && (
+      {errored ? (
+        <Card padding="2rem 1.25rem" className={styles.statePanel}>
+          <Icon icon="lucide:cloud-off" className={styles.stateIcon} />
+          <p className={styles.stateText}>
+            {translate({
+              id: 'pages.insights.status.error',
+              message: 'Unable to reach status server',
+            })}
+          </p>
+        </Card>
+      ) : (
         <div className={styles.list}>
           {loading ? (
             Array.from({ length: 4 }).map((_, i) => (

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -45,9 +45,9 @@ const MODIFICATION = translate({
   message: 'Live <b>Insights</b>',
 });
 
-function formatCompact(n: number): string {
+function formatCompact(n: number, locale?: string): string {
   if (!Number.isFinite(n)) return '–';
-  return new Intl.NumberFormat('en', {
+  return new Intl.NumberFormat(locale, {
     notation: 'compact',
     maximumFractionDigits: 1,
   }).format(Math.round(n));
@@ -149,8 +149,14 @@ function HeroMetric({
 
 function HeroGrid({ range }: { range: InsightsRange }) {
   const { data, status } = useUmamiStats(range);
+  const {
+    i18n: { currentLocale },
+  } = useDocusaurusContext();
+  const numberLocale = currentLocale === 'zh-Hans' ? 'zh' : 'en';
   const loading = status === 'loading';
   const errored = status === 'error';
+
+  const compact = (n: number) => formatCompact(n, numberLocale);
 
   const specs: MetricSpec[] = [
     {
@@ -159,7 +165,7 @@ function HeroGrid({ range }: { range: InsightsRange }) {
         id: 'pages.insights.metric.pageviews',
         message: 'Pageviews',
       }),
-      format: formatCompact,
+      format: compact,
     },
     {
       key: 'visitors',
@@ -167,7 +173,7 @@ function HeroGrid({ range }: { range: InsightsRange }) {
         id: 'pages.insights.metric.visitors',
         message: 'Visitors',
       }),
-      format: formatCompact,
+      format: compact,
     },
     {
       key: 'visits',
@@ -175,7 +181,7 @@ function HeroGrid({ range }: { range: InsightsRange }) {
         id: 'pages.insights.metric.visits',
         message: 'Visits',
       }),
-      format: formatCompact,
+      format: compact,
     },
     {
       key: 'avgVisit',

--- a/src/pages/insights/styles.module.css
+++ b/src/pages/insights/styles.module.css
@@ -17,7 +17,7 @@
 
 .heroGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
   gap: 1rem;
 }
 
@@ -57,23 +57,15 @@
 }
 
 .heroDeltaUp {
-  color: #1a8754;
+  color: var(--lk-color-up);
 }
 
 .heroDeltaDown {
-  color: #d93838;
+  color: var(--lk-color-down);
 }
 
 .heroDeltaFlat {
   color: var(--ifm-color-emphasis-500);
-}
-
-html[data-theme='dark'] .heroDeltaUp {
-  color: #34c77b;
-}
-
-html[data-theme='dark'] .heroDeltaDown {
-  color: #ff6b6b;
 }
 
 .skeletonText {
@@ -86,12 +78,31 @@ html[data-theme='dark'] .heroDeltaDown {
 @media (max-width: 480px) {
   .heroGrid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem;
   }
 }
 
 @media (max-width: 360px) {
   .heroGrid {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .heroTile {
+    --card-padding: 0.9rem 1rem 0.75rem !important;
+  }
+  .chartCard {
+    --card-padding: 1rem 0.85rem 0.85rem !important;
+  }
+}
+
+@media (max-width: 360px) {
+  .heroTile {
+    --card-padding: 0.85rem 0.9rem 0.7rem !important;
+  }
+  .chartCard {
+    --card-padding: 0.85rem 0.7rem 0.7rem !important;
   }
 }
 
@@ -104,7 +115,7 @@ html[data-theme='dark'] .heroDeltaDown {
 
 .metricsGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(280px, 100%), 1fr));
   gap: 1rem;
   margin-top: calc(1rem - clamp(2rem, 4vw, 3rem));
 }

--- a/src/utils/kuma.ts
+++ b/src/utils/kuma.ts
@@ -6,6 +6,7 @@ export interface KumaMonitor {
   name: string;
   sendUrl?: number;
   type?: string;
+  url?: string;
 }
 
 export interface KumaPublicGroup {


### PR DESCRIPTION
## Summary

Round of polish on the **Insights** page plus a small refactor of shared color / tooltip primitives.

### Status section
- Fetch 100 heartbeats and render a per-monitor bar; cell count adapts via `ResizeObserver` so the bar never overflows on narrow viewports
- Hover tooltip with timestamp / status / ping / message
- Monitor title is now a `<Link>` to the monitor's URL (depends on Kuma's *Send URL* toggle being on, with graceful fallback to plain text)
- Drop the *System status* heading and *All systems operational* pill in favor of a list-only layout; error state is now a centered card

### Color tokens (`color-mix()`)
- Add `--lk-color-up / down / pending / maintenance` in `custom.css` (light + dark)
- Replace every `rgba(var(--*-rgb), α)` across the project with `color-mix(in srgb, var(--*) N%, transparent)` — touches `laikit/Card`, `Segmented`, `IconBlock`, `Button`, `MetricList`, `UptimeSection`, `HeartbeatBar`, `NeuralNetwork`, `Bento`
- Drop the now-unused `-rgb` companions (`--lk-color-up-rgb`, `--lk-color-down-rgb`, `--link-card-accent-rgb`)
- Available status dot on the home page now also uses `--lk-color-up`

### Tooltip primitive
- Extract `src/components/laikit/Tooltip/` with `Tooltip.Label` / `Tooltip.Value` subcomponents
- `Sparkline` and `HeartbeatBar` both consume it; ~70 lines of duplicated CSS removed

### Responsive
- Insights page works down to a 200px viewport: hero/metric/uptime grids use `minmax(min(N, 100%), 1fr)`, hero/chart card padding tightens at <480px / <360px, `PageTitle` clamps smaller on <360px

### Misc
- `formatCompact` (insights hero + Sparkline tooltip) now follows Docusaurus `currentLocale` instead of hard-coded `'en'`
- Insights page link uses `<Link>` instead of `<a>` (auto handles external `target/rel`)
- `UptimeSection` row's name link wrapper keeps the clickable area limited to the text (was previously stretching across the flex line)
- Status card spacing aligned with the rest of the page sections

## Test plan
- [ ] Visit `/insights` in light & dark, sanity-check colors, tooltips, hover states
- [ ] Verify monitor titles navigate to the correct URLs (status page link); titles fall back to plain text if `sendUrl` is off
- [ ] Resize viewport from desktop down to ~200px — nothing should overflow horizontally
- [ ] Switch language to `zh-Hans`, verify number formatting uses CN-style compact notation
- [ ] Trigger Kuma error path (e.g. block `status.lailai.one` in DevTools) — expect the error card

🤖 Generated with [Claude Code](https://claude.com/claude-code)