### PR TITLE
Add Taiwan name override and tidy zh-Hans translations

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -59,18 +59,6 @@
   "components.solution.solution": {
     "message": "题解"
   },
-  "pages.friends.title": {
-    "message": "友链"
-  },
-  "pages.friends.description": {
-    "message": "真正的友谊是世上最稀有的东西"
-  },
-  "pages.friends.modification": {
-    "message": "我的<b>友链</b>"
-  },
-  "pages.friends.datacard.label": {
-    "message": "位朋友"
-  },
   "pages.insights.title": {
     "message": "实时洞察"
   },
@@ -125,44 +113,17 @@
   "pages.insights.metricList.countries": {
     "message": "访客地区"
   },
-  "pages.insights.metricList.devices": {
-    "message": "设备类型"
+  "pages.friends.title": {
+    "message": "友链"
   },
-  "pages.insights.status.operational": {
-    "message": "全部服务正常"
+  "pages.friends.description": {
+    "message": "真正的友谊是世上最稀有的东西"
   },
-  "pages.insights.status.degraded": {
-    "message": "部分服务异常"
+  "pages.friends.modification": {
+    "message": "我的<b>友链</b>"
   },
-  "pages.insights.status.major": {
-    "message": "服务中断"
-  },
-  "pages.insights.status.maintenance": {
-    "message": "维护中"
-  },
-  "pages.insights.status.unknown": {
-    "message": "状态未知"
-  },
-  "pages.insights.uptime.last24h": {
-    "message": "24 小时在线率"
-  },
-  "pages.insights.uptime.checks": {
-    "message": "近 {count} 次检测"
-  },
-  "pages.insights.uptime.avgPing": {
-    "message": "平均 {ping}ms"
-  },
-  "pages.insights.uptime.title": {
-    "message": "服务状态"
-  },
-  "pages.insights.status.loading": {
-    "message": "检测中…"
-  },
-  "pages.insights.status.error": {
-    "message": "无法连接监控服务"
-  },
-  "pages.insights.uptime.empty": {
-    "message": "暂无监控项"
+  "pages.friends.datacard.label": {
+    "message": "位朋友"
   },
   "pages.resources.title": {
     "message": "资源"
@@ -364,9 +325,6 @@
   "blog.pages.tags.tagSelect": {
     "message": "标签"
   },
-  "home.topbanner.title": {
-    "message": "Hello, I'm lailai"
-  },
   "home.bento.nav.contest": {
     "message": "竞赛"
   },
@@ -493,6 +451,36 @@
   "home.neuralnetwork.description": {
     "message": "在下方绘制数字 0–9，神经网络会识别您的手写数字"
   },
+  "home.topbanner.title": {
+    "message": "Hello, I'm lailai"
+  },
+  "pages.insights.heartbeat.up": {
+    "message": "正常"
+  },
+  "pages.insights.heartbeat.down": {
+    "message": "故障"
+  },
+  "pages.insights.heartbeat.pending": {
+    "message": "待定"
+  },
+  "pages.insights.heartbeat.maintenance": {
+    "message": "维护中"
+  },
+  "pages.insights.heartbeat.unknown": {
+    "message": "暂无数据"
+  },
+  "pages.insights.heartbeat.noData": {
+    "message": "暂无数据"
+  },
+  "pages.insights.uptime.avgPing": {
+    "message": "平均 {ping}ms"
+  },
+  "pages.insights.status.error": {
+    "message": "无法连接监控服务"
+  },
+  "pages.insights.uptime.empty": {
+    "message": "暂无监控项"
+  },
   "cookieConsent.title": {
     "message": "Cookie 设置"
   },
@@ -538,6 +526,10 @@
     "message": "回到顶部",
     "description": "The ARIA label for the back to top button"
   },
+  "theme.blog.archive.description": {
+    "message": "历史文章",
+    "description": "The page & hero description of the blog archive page"
+  },
   "theme.blog.paginator.navAriaLabel": {
     "message": "文章列表分页导航",
     "description": "The ARIA label for the blog pagination"
@@ -549,10 +541,6 @@
   "theme.blog.paginator.olderEntries": {
     "message": "较旧的文章",
     "description": "The label used to navigate to the older blog posts page (next page)"
-  },
-  "theme.blog.archive.description": {
-    "message": "历史文章",
-    "description": "The page & hero description of the blog archive page"
   },
   "theme.blog.post.paginator.navAriaLabel": {
     "message": "文章分页导航",
@@ -649,21 +637,17 @@
     "message": "最后{byUser}{atDate}更新",
     "description": "The sentence used to display when a page has been last updated, and by who"
   },
-  "theme.NotFound.title": {
-    "message": "找不到页面",
-    "description": "The title of the 404 page"
-  },
   "theme.navbar.mobileVersionsDropdown.label": {
     "message": "选择版本",
     "description": "The label for the navbar versions dropdown on mobile view"
   },
+  "theme.NotFound.title": {
+    "message": "找不到页面",
+    "description": "The title of the 404 page"
+  },
   "theme.tags.tagsListLabel": {
     "message": "标签：",
     "description": "The label alongside a tag list"
-  },
-  "theme.AnnouncementBar.closeButtonAriaLabel": {
-    "message": "关闭",
-    "description": "The ARIA label for close button of announcement bar"
   },
   "theme.admonition.caution": {
     "message": "警告",
@@ -689,6 +673,10 @@
     "message": "注意",
     "description": "The default label used for the Warning admonition (:::warning)"
   },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "关闭",
+    "description": "The ARIA label for close button of announcement bar"
+  },
   "theme.blog.sidebar.navAriaLabel": {
     "message": "最近文章导航",
     "description": "The ARIA label for recent posts in the blog sidebar"
@@ -709,6 +697,10 @@
     "message": "主导航",
     "description": "The ARIA label for the main navigation"
   },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "选择语言",
+    "description": "The label for the mobile language switcher dropdown"
+  },
   "theme.NotFound.p1": {
     "message": "我们找不到您要找的页面。",
     "description": "The first paragraph of the 404 page"
@@ -717,17 +709,9 @@
     "message": "请联系原始链接来源网站的所有者，并告知他们链接已损坏。",
     "description": "The 2nd paragraph of the 404 page"
   },
-  "theme.navbar.mobileLanguageDropdown.label": {
-    "message": "选择语言",
-    "description": "The label for the mobile language switcher dropdown"
-  },
   "theme.TOCCollapsible.toggleButtonLabel": {
     "message": "本页总览",
     "description": "The label used by the button on the collapsible TOC component"
-  },
-  "theme.blog.post.readingTime.plurals": {
-    "message": "阅读需 {readingTime} 分钟",
-    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.blog.post.readMore": {
     "message": "阅读更多",
@@ -736,6 +720,10 @@
   "theme.blog.post.readMoreLabel": {
     "message": "阅读 {title} 的全文",
     "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "阅读需 {readingTime} 分钟",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
   },
   "theme.CodeBlock.copy": {
     "message": "复制",
@@ -799,6 +787,38 @@
   },
   "theme.SearchBar.seeAll": {
     "message": "查看全部 {count} 个结果"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "找到 {count} 份文件",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "「{query}」的搜索结果",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "在文档中搜索",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "在此输入搜索字词",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "搜索",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "通过 Algolia 搜索",
+    "description": "The description label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "未找到任何结果",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "正在获取新的搜索结果...",
+    "description": "The paragraph for fetching new search results"
   },
   "theme.SearchBar.label": {
     "message": "搜索",
@@ -995,38 +1015,6 @@
   "theme.SearchModal.placeholder": {
     "message": "搜索文档",
     "description": "The placeholder of the input of the DocSearch pop-up modal"
-  },
-  "theme.SearchPage.documentsFound.plurals": {
-    "message": "找到 {count} 份文件",
-    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
-  },
-  "theme.SearchPage.existingResultsTitle": {
-    "message": "「{query}」的搜索结果",
-    "description": "The search page title for non-empty query"
-  },
-  "theme.SearchPage.emptyResultsTitle": {
-    "message": "在文档中搜索",
-    "description": "The search page title for empty query"
-  },
-  "theme.SearchPage.inputPlaceholder": {
-    "message": "在此输入搜索字词",
-    "description": "The placeholder for search page input"
-  },
-  "theme.SearchPage.inputLabel": {
-    "message": "搜索",
-    "description": "The ARIA label for search page input"
-  },
-  "theme.SearchPage.algoliaLabel": {
-    "message": "通过 Algolia 搜索",
-    "description": "The description label for Algolia mention"
-  },
-  "theme.SearchPage.noResultsText": {
-    "message": "未找到任何结果",
-    "description": "The paragraph for empty search result"
-  },
-  "theme.SearchPage.fetchingNewResults": {
-    "message": "正在获取新的搜索结果...",
-    "description": "The paragraph for fetching new search results"
   },
   "theme.Playground.liveEditor": {
     "message": "实时编辑器",

--- a/src/components/laikit/Button/styles.module.css
+++ b/src/components/laikit/Button/styles.module.css
@@ -20,7 +20,8 @@
 
 .button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ifm-color-primary) 24%, transparent);
+  box-shadow: 0 0 0 3px
+    color-mix(in srgb, var(--ifm-color-primary) 24%, transparent);
 }
 
 .button:disabled,

--- a/src/components/laikit/IconBlock/styles.module.css
+++ b/src/components/laikit/IconBlock/styles.module.css
@@ -18,7 +18,8 @@
     color-mix(in srgb, var(--ifm-color-primary) 8%, transparent)
   );
   color: var(--ifm-color-primary);
-  border: 1px solid color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
+  border: 1px solid
+    color-mix(in srgb, var(--ifm-color-primary) 18%, transparent);
 }
 
 html[data-theme='dark'] .accent {

--- a/src/components/laikit/Page/index.tsx
+++ b/src/components/laikit/Page/index.tsx
@@ -39,7 +39,5 @@ export function PageContent({
   className?: string;
   children: ReactNode;
 }) {
-  return (
-    <Tag className={clsx(styles.pageContent, className)}>{children}</Tag>
-  );
+  return <Tag className={clsx(styles.pageContent, className)}>{children}</Tag>;
 }

--- a/src/components/laikit/Segmented/styles.module.css
+++ b/src/components/laikit/Segmented/styles.module.css
@@ -76,7 +76,8 @@ html[data-theme='dark'] .item:hover {
 }
 
 .item:focus-visible {
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--ifm-color-primary) 40%, transparent);
 }
 
 .itemActive,

--- a/src/hooks/useUmamiMetric.ts
+++ b/src/hooks/useUmamiMetric.ts
@@ -20,9 +20,7 @@ export function useUmamiMetric(
   useEffect(() => {
     const controller = new AbortController();
     const endAt =
-      range === 1
-        ? Math.ceil(Date.now() / 3600_000) * 3600_000
-        : Date.now();
+      range === 1 ? Math.ceil(Date.now() / 3600_000) * 3600_000 : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
 
     (async () => {

--- a/src/hooks/useUmamiPageviewsSeries.ts
+++ b/src/hooks/useUmamiPageviewsSeries.ts
@@ -119,9 +119,7 @@ export function useUmamiPageviewsSeries(range: InsightsRange) {
   useEffect(() => {
     const controller = new AbortController();
     const endAt =
-      range === 1
-        ? Math.ceil(Date.now() / 3600_000) * 3600_000
-        : Date.now();
+      range === 1 ? Math.ceil(Date.now() / 3600_000) * 3600_000 : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
     const unit = rangeUnit(range);
     const timezone =

--- a/src/hooks/useUmamiStats.ts
+++ b/src/hooks/useUmamiStats.ts
@@ -24,9 +24,7 @@ export function useUmamiStats(range: InsightsRange) {
   useEffect(() => {
     const controller = new AbortController();
     const endAt =
-      range === 1
-        ? Math.ceil(Date.now() / 3600_000) * 3600_000
-        : Date.now();
+      range === 1 ? Math.ceil(Date.now() / 3600_000) * 3600_000 : Date.now();
     const startAt = endAt - range * 24 * 60 * 60 * 1000;
 
     (async () => {

--- a/src/pages/_components/NeuralNetwork/styles.module.css
+++ b/src/pages/_components/NeuralNetwork/styles.module.css
@@ -17,7 +17,11 @@
   /* Aligned with Lorenz Attractor's blue/orange trail palette. */
   --nn-connection-negative-rgb: 249, 115, 22;
   --nn-connection-positive-rgb: 29, 155, 240;
-  --nn-connection-animation: color-mix(in srgb, var(--ifm-color-primary) 55%, transparent);
+  --nn-connection-animation: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 55%,
+    transparent
+  );
   --nn-connection-default: #666666;
 
   --nn-grid-white: #ffffff;
@@ -54,7 +58,11 @@
   --nn-neuron-gray-base: 255;
   --nn-neuron-gray-multiplier: -255;
 
-  --nn-connection-animation: color-mix(in srgb, var(--ifm-color-primary) 70%, transparent);
+  --nn-connection-animation: color-mix(
+    in srgb,
+    var(--ifm-color-primary) 70%,
+    transparent
+  );
   --nn-connection-default: #c7d2fe;
 
   --nn-grid-white: #000000;

--- a/src/pages/insights/_components/HeartbeatBar.tsx
+++ b/src/pages/insights/_components/HeartbeatBar.tsx
@@ -97,7 +97,10 @@ function formatTooltipDate(iso: string, locale: string): string {
   });
 }
 
-export default function HeartbeatBar({ beats, slots = 100 }: HeartbeatBarProps) {
+export default function HeartbeatBar({
+  beats,
+  slots = 100,
+}: HeartbeatBarProps) {
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
   const [wrapRef, fitSlots] = useResponsiveSlots(slots);
   const {

--- a/src/pages/insights/_components/Sparkline.tsx
+++ b/src/pages/insights/_components/Sparkline.tsx
@@ -181,14 +181,18 @@ export default function Sparkline({
 
   const spanDays =
     data.length > 1
-      ? (parseDate(data[lastIndex].x).getTime() - parseDate(data[0].x).getTime()) /
+      ? (parseDate(data[lastIndex].x).getTime() -
+          parseDate(data[0].x).getTime()) /
         86400000
       : 0;
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!containerRef.current || values.length === 0) return;
     const rect = containerRef.current.getBoundingClientRect();
-    const ratio = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    const ratio = Math.max(
+      0,
+      Math.min(1, (e.clientX - rect.left) / rect.width)
+    );
     setHoverIdx(Math.round(ratio * lastIndex));
   };
   const onPointerLeave = () => setHoverIdx(null);

--- a/src/pages/insights/_components/UptimeSection.module.css
+++ b/src/pages/insights/_components/UptimeSection.module.css
@@ -64,17 +64,20 @@
 
 .dotDown {
   background: var(--lk-color-down);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-down) 20%, transparent);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--lk-color-down) 20%, transparent);
 }
 
 .dotPending {
   background: var(--lk-color-pending);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-pending) 20%, transparent);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--lk-color-pending) 20%, transparent);
 }
 
 .dotMaintenance {
   background: var(--lk-color-maintenance);
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-maintenance) 20%, transparent);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--lk-color-maintenance) 20%, transparent);
 }
 
 .dotEmpty {
@@ -86,7 +89,8 @@ html[data-theme='dark'] .dotUp {
 }
 
 html[data-theme='dark'] .dotDown {
-  box-shadow: 0 0 0 4px color-mix(in srgb, var(--lk-color-down) 22%, transparent);
+  box-shadow: 0 0 0 4px
+    color-mix(in srgb, var(--lk-color-down) 22%, transparent);
 }
 
 .nameWrap {

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -270,6 +270,18 @@ function RangeBar({
   );
 }
 
+const COUNTRY_NAME_OVERRIDES: Record<string, Record<string, string>> = {
+  TW: { en: 'Taiwan', zh: '台湾' },
+};
+
+function countryName(code: string, lang: string): string {
+  return (
+    COUNTRY_NAME_OVERRIDES[code]?.[lang] ??
+    countries.getName(code, lang) ??
+    code
+  );
+}
+
 function flagImageUrl(code: string): string {
   return `https://analytics.lailai.one/images/country/${code.toLowerCase()}.png`;
 }
@@ -379,7 +391,7 @@ function MetricsGrid({ range }: { range: InsightsRange }) {
               aria-hidden="true"
               loading="lazy"
             />
-            <span>{countries.getName(code, lang) || code}</span>
+            <span>{countryName(code, lang)}</span>
           </>
         )}
       />


### PR DESCRIPTION
## Summary

- Override Taiwan country label on the Insights page to "Taiwan" / "台湾" instead of the ISO 3166-1 default `Taiwan, Province of China`. Hooked via a tiny `COUNTRY_NAME_OVERRIDES` map so other names still go through `i18n-iso-countries`.
- Translate the 6 new heartbeat status keys (Up/Down/Pending/Maintenance/No data) into Chinese to match existing tone.
- Reorder \`i18n/zh-Hans/code.json\` to match the canonical order produced by \`npm run i18n\` from scratch.
- Drop 10 orphaned zh-Hans entries (System status pill, recent-checks line, 24h uptime label, etc.) left behind by the recent insights refactor.
- \`npm run check\` (i18n + format + typecheck) passes.

## Test plan
- [ ] Visit \`/insights\` in zh-Hans, confirm Top countries list shows "台湾" (no "中华人民共和国" suffix)
- [ ] Hover heartbeat cells in zh-Hans, confirm tooltip status text reads 正常 / 故障 / 待定 / 维护中 / 暂无数据

🤖 Generated with [Claude Code](https://claude.com/claude-code)