### PR TITLE
Inline header/container wrappers in page entry components

### DIFF
--- a/src/pages/friends/index.tsx
+++ b/src/pages/friends/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@site/src/components/laikit/Page';
 import DataCard from '@site/src/components/laikit/DataCard';
 import LinkCard from '@site/src/components/laikit/LinkCard';
-import { FriendItem, FRIEND_LIST } from '@site/src/data/friends';
+import { FRIEND_LIST } from '@site/src/data/friends';
 import { translate } from '@docusaurus/Translate';
 import styles from './styles.module.css';
 
@@ -24,51 +24,33 @@ const MODIFICATION = translate({
   message: 'My <b>Friends</b>',
 });
 
-function FriendCard({ friend }: { friend: FriendItem }) {
-  return (
-    <LinkCard
-      href={friend.href}
-      title={friend.title}
-      description={friend.description ?? friend.href}
-      image={friend.avatar}
-      imageVariant="avatar"
-      fallbackIcon="lucide:user"
-    />
-  );
-}
-
-function FriendsMain() {
-  return (
-    <PageContent className={styles.layout}>
-      {FRIEND_LIST.map((friend, index) => (
-        <FriendCard key={`${friend.title}-${index}`} friend={friend} />
-      ))}
-    </PageContent>
-  );
-}
-
-function FriendsHeader() {
-  const totalFriends = FRIEND_LIST.length;
-  return (
-    <PageHeader>
-      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
-      <DataCard
-        value={totalFriends}
-        label={translate({
-          id: 'pages.friends.datacard.label',
-          message: 'Friends',
-        })}
-        icon="lucide:users"
-      />
-    </PageHeader>
-  );
-}
-
 export default function Friends(): ReactNode {
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <FriendsHeader />
-      <FriendsMain />
+      <PageHeader>
+        <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+        <DataCard
+          value={FRIEND_LIST.length}
+          label={translate({
+            id: 'pages.friends.datacard.label',
+            message: 'Friends',
+          })}
+          icon="lucide:users"
+        />
+      </PageHeader>
+      <PageContent className={styles.layout}>
+        {FRIEND_LIST.map((friend, index) => (
+          <LinkCard
+            key={`${friend.title}-${index}`}
+            href={friend.href}
+            title={friend.title}
+            description={friend.description ?? friend.href}
+            image={friend.avatar}
+            imageVariant="avatar"
+            fallbackIcon="lucide:user"
+          />
+        ))}
+      </PageContent>
     </Layout>
   );
 }

--- a/src/pages/resources/index.tsx
+++ b/src/pages/resources/index.tsx
@@ -174,35 +174,7 @@ function CategorySection({ category }: { category: ResourceCategoryItem }) {
   );
 }
 
-function ResourcesHeader() {
-  return (
-    <PageHeader>
-      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
-      <DataCard
-        items={[
-          {
-            value: RESOURCE_LIST.length,
-            label: translate({
-              id: 'pages.resources.datacard.label1',
-              message: 'Categories',
-            }),
-            icon: 'lucide:folder',
-          },
-          {
-            value: RESOURCE_LIST.flatMap((cat) => cat.resources).length,
-            label: translate({
-              id: 'pages.resources.datacard.label2',
-              message: 'Resources',
-            }),
-            icon: 'lucide:database',
-          },
-        ]}
-      />
-    </PageHeader>
-  );
-}
-
-function ResourcesMain() {
+export default function Resources(): ReactNode {
   const [activeCategory, setActiveCategory] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -211,47 +183,67 @@ function ResourcesMain() {
   }, [activeCategory, searchQuery]);
 
   return (
-    <PageContent className={styles.layout}>
-      <SearchBar value={searchQuery} onChange={setSearchQuery} />
-
-      <CategoryNav
-        categories={RESOURCE_LIST}
-        activeCategory={activeCategory}
-        onCategoryChange={setActiveCategory}
-      />
-
-      {filteredCategories.length > 0 ? (
-        filteredCategories.map((category) => (
-          <CategorySection key={category.title} category={category} />
-        ))
-      ) : (
-        <div className={styles.noResults}>
-          <p>
-            {translate(
-              {
-                id: 'pages.resources.noresults.description',
-                message: 'No resources found matching "{query}".',
-              },
-              { query: searchQuery }
-            )}
-          </p>
-          <Button variant="primary" rounded onClick={() => setSearchQuery('')}>
-            {translate({
-              id: 'pages.resources.noresults.clear',
-              message: 'Clear Search',
-            })}
-          </Button>
-        </div>
-      )}
-    </PageContent>
-  );
-}
-
-export default function Resources(): ReactNode {
-  return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <ResourcesHeader />
-      <ResourcesMain />
+      <PageHeader>
+        <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+        <DataCard
+          items={[
+            {
+              value: RESOURCE_LIST.length,
+              label: translate({
+                id: 'pages.resources.datacard.label1',
+                message: 'Categories',
+              }),
+              icon: 'lucide:folder',
+            },
+            {
+              value: RESOURCE_LIST.flatMap((cat) => cat.resources).length,
+              label: translate({
+                id: 'pages.resources.datacard.label2',
+                message: 'Resources',
+              }),
+              icon: 'lucide:database',
+            },
+          ]}
+        />
+      </PageHeader>
+      <PageContent className={styles.layout}>
+        <SearchBar value={searchQuery} onChange={setSearchQuery} />
+
+        <CategoryNav
+          categories={RESOURCE_LIST}
+          activeCategory={activeCategory}
+          onCategoryChange={setActiveCategory}
+        />
+
+        {filteredCategories.length > 0 ? (
+          filteredCategories.map((category) => (
+            <CategorySection key={category.title} category={category} />
+          ))
+        ) : (
+          <div className={styles.noResults}>
+            <p>
+              {translate(
+                {
+                  id: 'pages.resources.noresults.description',
+                  message: 'No resources found matching "{query}".',
+                },
+                { query: searchQuery }
+              )}
+            </p>
+            <Button
+              variant="primary"
+              rounded
+              onClick={() => setSearchQuery('')}
+            >
+              {translate({
+                id: 'pages.resources.noresults.clear',
+                message: 'Clear Search',
+              })}
+            </Button>
+          </div>
+        )}
+      </PageContent>
     </Layout>
   );
 }

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -435,22 +435,6 @@ function QuickActions() {
   );
 }
 
-function SettingsHeader() {
-  return (
-    <PageHeader>
-      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
-      <DataCard
-        value={6}
-        label={translate({
-          id: 'pages.settings.datacard.label',
-          message: 'Settings',
-        })}
-        icon="lucide:settings"
-      />
-    </PageHeader>
-  );
-}
-
 function LanguageSettings() {
   const {
     i18n: { currentLocale, locales, localeConfigs },
@@ -491,24 +475,28 @@ function LanguageSettings() {
   );
 }
 
-function SettingsContainer() {
-  return (
-    <PageContent className={styles.layout}>
-      <ThemeSettings />
-      <LanguageSettings />
-      <AccentColor />
-      <Typography />
-      <ExperimentalFeatures />
-      <QuickActions />
-    </PageContent>
-  );
-}
-
 export default function Settings(): ReactNode {
   return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <SettingsHeader />
-      <SettingsContainer />
+      <PageHeader>
+        <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+        <DataCard
+          value={6}
+          label={translate({
+            id: 'pages.settings.datacard.label',
+            message: 'Settings',
+          })}
+          icon="lucide:settings"
+        />
+      </PageHeader>
+      <PageContent className={styles.layout}>
+        <ThemeSettings />
+        <LanguageSettings />
+        <AccentColor />
+        <Typography />
+        <ExperimentalFeatures />
+        <QuickActions />
+      </PageContent>
     </Layout>
   );
 }

--- a/src/pages/travel/index.tsx
+++ b/src/pages/travel/index.tsx
@@ -25,42 +25,36 @@ const MODIFICATION = translate({
   message: '<b>Travel</b> Record',
 });
 
-function TravelHeader() {
+export default function Travel(): ReactNode {
   const countryCount = new Set(getTravelCountryCodes(TRAVEL_LIST)).size;
   const yearCount =
     new Date().getFullYear() - parseInt(TRAVEL_LIST[0].title.substring(0, 4));
 
   return (
-    <PageHeader>
-      <PageTitle title={MODIFICATION} description={DESCRIPTION} />
-      <DataCard
-        items={[
-          {
-            value: countryCount,
-            label: translate({
-              id: 'pages.travel.datacard.label1',
-              message: 'Countries',
-            }),
-            icon: 'lucide:globe',
-          },
-          {
-            value: yearCount,
-            label: translate({
-              id: 'pages.travel.datacard.label2',
-              message: 'Years',
-            }),
-            icon: 'lucide:route',
-          },
-        ]}
-      />
-    </PageHeader>
-  );
-}
-
-export default function Travel(): ReactNode {
-  return (
     <Layout title={TITLE} description={DESCRIPTION}>
-      <TravelHeader />
+      <PageHeader>
+        <PageTitle title={MODIFICATION} description={DESCRIPTION} />
+        <DataCard
+          items={[
+            {
+              value: countryCount,
+              label: translate({
+                id: 'pages.travel.datacard.label1',
+                message: 'Countries',
+              }),
+              icon: 'lucide:globe',
+            },
+            {
+              value: yearCount,
+              label: translate({
+                id: 'pages.travel.datacard.label2',
+                message: 'Years',
+              }),
+              icon: 'lucide:route',
+            },
+          ]}
+        />
+      </PageHeader>
       <PageContent>
         <TravelMap />
         <TravelTimeline />


### PR DESCRIPTION
## Summary

Flatten the small wrapper components on each top-level page that existed only to compose `<PageHeader>` + `<PageContent>`. Pure refactor, no UI change.

- **friends**: drop `FriendsHeader`, `FriendsMain`, `FriendCard`
- **travel**: drop `TravelHeader`
- **resources**: drop `ResourcesHeader`, `ResourcesMain` (state hooks now live in `Resources` directly)
- **settings**: drop `SettingsHeader`, `SettingsContainer`

Net -44 lines. \`tsc\` clean.

## Test plan
- [ ] \`/friends\`, \`/travel\`, \`/resources\`, \`/settings\` render identically pre/post

🤖 Generated with [Claude Code](https://claude.com/claude-code)