### PR TITLE
Reset Settings: include accent color, drop dead key

### DIFF
--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -375,8 +375,8 @@ function QuickActions() {
     localStorage.removeItem('theme');
     localStorage.removeItem('global-font-size');
     localStorage.removeItem('global-line-height');
-    localStorage.removeItem('settings-notifications');
     localStorage.removeItem('settings-experimental');
+    localStorage.removeItem('ifm-theme-colors');
     window.location.reload();
   }
 


### PR DESCRIPTION
## Summary

\`Reset Settings\` previously left the **Accent Color** untouched (stored under \`ifm-theme-colors\`) and tried to remove a long-dead \`settings-notifications\` key. Now:

- Adds \`ifm-theme-colors\` so the accent color also resets
- Removes the orphan \`settings-notifications\` removal — no code in the repo writes it

The button now truly resets every persisted setting (theme, font size, line height, experimental flags, accent color).

## Test plan
- [ ] Change accent color, click Reset Settings, confirm accent reverts
- [ ] Change theme/font/experimental, click Reset, confirm all revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)