### PR TITLE
Add formatBeijingDate util and fix UTC date drift

### DIFF
--- a/src/pages/_components/Bento/index.tsx
+++ b/src/pages/_components/Bento/index.tsx
@@ -7,6 +7,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { Icon } from '@iconify/react';
 import { COMMUNITY_LIST } from '@site/src/data/community';
 import { getRecentBlogPosts } from '@site/src/utils/blogData';
+import { formatBeijingDate } from '@site/src/utils/format';
 import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
@@ -149,11 +150,10 @@ export default function Bento() {
   );
   const latestPost = useMemo(() => getRecentBlogPosts(1)[0] ?? null, []);
   const latestPostDate = latestPost
-    ? new Date(latestPost.date).toLocaleDateString(i18n.currentLocale, {
+    ? formatBeijingDate(latestPost.date, i18n.currentLocale, {
         year: 'numeric',
         month: 'long',
         day: 'numeric',
-        timeZone: 'UTC',
       })
     : '';
 

--- a/src/pages/_components/Blog/index.tsx
+++ b/src/pages/_components/Blog/index.tsx
@@ -9,6 +9,7 @@ import {
   getRecentBlogPosts,
   type ProcessedBlogPost,
 } from '@site/src/utils/blogData';
+import { formatBeijingDate } from '@site/src/utils/format';
 import SectionContainer from '@site/src/components/laikit/Section';
 import styles from './styles.module.css';
 
@@ -30,11 +31,10 @@ const formatDate = (dateString: string, locale: string): string => {
     return dateString;
   }
 
-  return date.toLocaleDateString(locale, {
+  return formatBeijingDate(date, locale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
-    timeZone: 'UTC',
   });
 };
 

--- a/src/theme/BlogShared/ArchiveList.tsx
+++ b/src/theme/BlogShared/ArchiveList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import { BlogCard } from '../BlogShared/Components';
+import { formatBeijingDate } from '@site/src/utils/format';
 import styles from './styles.module.css';
 
 type PostLike = {
@@ -17,7 +18,7 @@ export function BlogArchiveList({ posts }: { posts: PostLike[] }) {
     const map = new Map<number, PostLike[]>();
 
     posts.forEach((p) => {
-      const year = new Date(p.metadata.date).getUTCFullYear();
+      const year = Number(formatBeijingDate(p.metadata.date).slice(0, 4));
       const arr = map.get(year);
       if (arr) arr.push(p);
       else map.set(year, [p]);
@@ -44,7 +45,7 @@ export function BlogArchiveList({ posts }: { posts: PostLike[] }) {
             {yearPosts.map((post) => (
               <li key={post.metadata.permalink} className={styles.recentItem}>
                 <div className={styles.recentDate}>
-                  {post.metadata.date.slice(5, 10)}
+                  {formatBeijingDate(post.metadata.date).slice(5, 10)}
                 </div>
                 <Link
                   to={post.metadata.permalink}

--- a/src/theme/BlogShared/PostsListLayout.tsx
+++ b/src/theme/BlogShared/PostsListLayout.tsx
@@ -10,6 +10,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import { translate } from '@docusaurus/Translate';
 import IconText from '@site/src/components/laikit/IconText';
+import { formatBeijingDate } from '@site/src/utils/format';
 import MDXContent from '@theme/MDXContent';
 import styles from './styles.module.css';
 
@@ -91,7 +92,9 @@ function PostCard({ item }: PostCardProps) {
       </div>
       <div className={styles.postMeta}>
         <IconText icon="lucide:calendar" monochrome>
-          <time dateTime={metadata.date}>{metadata.date.slice(0, 10)}</time>
+          <time dateTime={metadata.date}>
+            {formatBeijingDate(metadata.date)}
+          </time>
         </IconText>
         {!!metadata.readingTime && (
           <>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -9,3 +9,14 @@ export function formatCompact(
     maximumFractionDigits: precision,
   }).format(n);
 }
+
+export function formatBeijingDate(
+  date: Date | string | number,
+  locale: string = 'en-CA',
+  options: Intl.DateTimeFormatOptions = {}
+): string {
+  return new Date(date).toLocaleDateString(locale, {
+    timeZone: 'Asia/Shanghai',
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary

\`metadata.date.slice(0, 10)\` and \`getUTCFullYear()\` were silently using the UTC representation of normalized dates, so blog posts with early-morning Beijing times (e.g. \`2077-01-01T00:00\`) rendered as the previous day in the list/archive views.

- Add \`formatBeijingDate(date, locale='en-CA', options={})\` to \`src/utils/format.ts\` — single source of truth for "render a date in Beijing time"
- Replaces \`slice\` / \`getUTCFullYear\` / inline \`toLocaleDateString\` across **5 callsites**: PostsListLayout, ArchiveList (year + month-day), Bento, \_components/Blog
- Default \`en-CA\` yields \`YYYY-MM-DD\` — drop-in replacement for the old slice visual
- Callers that need localized long form pass \`i18n.currentLocale\` + \`options\`
- Zero data migration: 138 frontmatter dates untouched

## Test plan
- [ ] \`/blog\` list — \`2077-01-01\` welcome post shows \`2077-01-01\`, not \`2076-12-31\`
- [ ] \`/blog/archive\` — year groups + month-day labels match Beijing date
- [ ] \`/\` Bento "Latest Post" card and home page "Learning & Practice" cards — long-form date matches
- [ ] zh-Hans locale renders \`2077年1月1日\` style on long-form sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)