### PR TITLE
Add Runtime snapshot card to Insights page

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,10 +2,26 @@ import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
+import { execSync } from 'child_process';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 
 const defaultLocale = 'en';
+
+function safeGit(cmd: string, fallback = ''): string {
+  try {
+    return execSync(cmd, { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+  } catch {
+    return fallback;
+  }
+}
+
+const BUILD_TIME = new Date().toISOString();
+const GIT_SHA = safeGit('git rev-parse --short=8 HEAD', 'dev');
+const GIT_COUNT = safeGit('git rev-list --count HEAD', '0');
+const DEBUG_ID = `LAI#${GIT_SHA.toUpperCase()}.${GIT_COUNT}`;
 
 const config: Config = {
   title: "lailai's Home",
@@ -26,6 +42,11 @@ const config: Config = {
 
   trailingSlash: false,
   onBrokenLinks: 'throw',
+
+  customFields: {
+    buildTime: BUILD_TIME,
+    debugId: DEBUG_ID,
+  },
 
   i18n: {
     defaultLocale,

--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -98,6 +98,9 @@
   "pages.insights.chart.title": {
     "message": "浏览量趋势"
   },
+  "pages.insights.sysStatus.title": {
+    "message": "运行时快照"
+  },
   "pages.insights.metricList.pages": {
     "message": "热门页面"
   },
@@ -1072,5 +1075,8 @@
   "theme.common.skipToMainContent": {
     "message": "跳到主要内容",
     "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "pages.insights.sysStatus.srLabel": {
+    "message": "System status overview"
   }
 }

--- a/src/hooks/useSysStatus.ts
+++ b/src/hooks/useSysStatus.ts
@@ -1,0 +1,60 @@
+import { useEffect, useRef, useState } from 'react';
+import type { FetchStatus } from './useUmamiStats';
+
+export interface SysStatus {
+  cpu: number | null;
+  mem: number | null;
+  mem_used_mb?: number;
+  mem_total_mb?: number;
+  uptime?: number;
+  load?: number[];
+  cores?: number;
+  disk?: number | null;
+  swap?: number | null;
+  last_deploy?: number | null;
+  tls_expires_in?: number | null;
+  ip?: string | null;
+  ts?: number;
+}
+
+const ENDPOINT = 'https://lailai.one/api/sys';
+const POLL_MS = 8000;
+
+export function useSysStatus() {
+  const [data, setData] = useState<SysStatus | null>(null);
+  const [status, setStatus] = useState<FetchStatus>('loading');
+  const aliveRef = useRef(true);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    const controller = new AbortController();
+
+    const fetchOnce = async () => {
+      try {
+        const res = await fetch(ENDPOINT, {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(String(res.status));
+        const json = (await res.json()) as SysStatus;
+        if (!aliveRef.current) return;
+        setData(json);
+        setStatus('success');
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        if (!aliveRef.current) return;
+        setStatus('error');
+      }
+    };
+
+    fetchOnce();
+    const id = window.setInterval(fetchOnce, POLL_MS);
+    return () => {
+      aliveRef.current = false;
+      controller.abort();
+      window.clearInterval(id);
+    };
+  }, []);
+
+  return { data, status };
+}

--- a/src/pages/insights/_components/SysStatusCard.module.css
+++ b/src/pages/insights/_components/SysStatusCard.module.css
@@ -1,0 +1,113 @@
+.card {
+  font-family:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono',
+    monospace;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  position: relative;
+  overflow: hidden;
+  margin-top: calc(1rem - clamp(2rem, 4vw, 3rem));
+}
+
+/* subtle terminal-like grid */
+.card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(
+      to right,
+      color-mix(in srgb, var(--lk-color-up) 4%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--lk-color-up) 4%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 22px 22px;
+  opacity: 0.55;
+  mask-image: radial-gradient(ellipse at center, black 50%, transparent 95%);
+}
+
+.body {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem 1.75rem;
+  position: relative;
+  z-index: 1;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.cell {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.key {
+  color: var(--ifm-color-emphasis-600);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.val {
+  color: var(--ifm-color-emphasis-900);
+  font-weight: 600;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.muted {
+  color: var(--ifm-color-emphasis-500);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.cardSkeleton {
+  composes: skeleton from '../../../components/laikit/Skeleton/styles.module.css';
+  height: 240px;
+  border-radius: 16px;
+}
+
+@media (max-width: 768px) {
+  .body {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem 1.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .body {
+    grid-template-columns: 1fr;
+  }
+  .card {
+    --card-padding: 1rem 1.05rem !important;
+  }
+}

--- a/src/pages/insights/_components/SysStatusCard.tsx
+++ b/src/pages/insights/_components/SysStatusCard.tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useState } from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { translate } from '@docusaurus/Translate';
+import { Icon } from '@iconify/react';
+import Card from '@site/src/components/laikit/Card';
+import { useSysStatus } from '@site/src/hooks/useSysStatus';
+import metricListStyles from './MetricList.module.css';
+import styles from './SysStatusCard.module.css';
+
+const PING_TARGET = 'https://analytics.lailai.one/script.js';
+const PING_INTERVAL = 8000;
+const TICK_INTERVAL = 1000;
+
+function detectBrowser(ua: string): string {
+  if (/Edg\//.test(ua)) return 'Edge';
+  if (/OPR\//.test(ua) || / Opera/.test(ua)) return 'Opera';
+  if (/Firefox\//.test(ua)) return 'Firefox';
+  if (/Chrome\//.test(ua) && !/Chromium/.test(ua)) return 'Chrome';
+  if (/Safari\//.test(ua)) return 'Safari';
+  return 'Unknown';
+}
+
+function formatUptimeSec(s: number): string {
+  if (!Number.isFinite(s) || s < 0) return '—';
+  if (s < 60) return `${Math.floor(s)}s`;
+  const m = Math.floor(s / 60);
+  const r = Math.floor(s % 60);
+  if (m < 60) return `${m}m ${r}s`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  if (h < 24) return `${h}h ${rm}m`;
+  const d = Math.floor(h / 24);
+  const rh = h % 24;
+  return `${d}d ${rh}h`;
+}
+
+function formatDateTime(d: Date): string {
+  const p = (n: number) => n.toString().padStart(2, '0');
+  return (
+    `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ` +
+    `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+  );
+}
+
+function formatBuildTime(iso: string): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const p = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+function formatIp(ip: string | null | undefined): string {
+  if (!ip) return '—';
+  if (ip.length <= 21) return ip;
+  return `${ip.slice(0, 9)}…${ip.slice(-9)}`;
+}
+
+function formatRelative(ms: number, nowMs: number): string {
+  const diff = Math.max(0, Math.round((nowMs - ms) / 1000));
+  if (diff < 5) return 'just now';
+  if (diff < 60) return `${diff}s ago`;
+  const m = Math.floor(diff / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function usePing(): number | null {
+  const [val, setVal] = useState<number | null>(null);
+  useEffect(() => {
+    let stopped = false;
+    const measure = async () => {
+      const t0 = performance.now();
+      try {
+        await fetch(`${PING_TARGET}?t=${Date.now()}`, {
+          method: 'HEAD',
+          mode: 'no-cors',
+          cache: 'no-store',
+        });
+        if (stopped) return;
+        setVal(Math.round(performance.now() - t0));
+      } catch {
+        if (!stopped) setVal(null);
+      }
+    };
+    measure();
+    const id = window.setInterval(measure, PING_INTERVAL);
+    return () => {
+      stopped = true;
+      window.clearInterval(id);
+    };
+  }, []);
+  return val;
+}
+
+function useNow(): Date {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), TICK_INTERVAL);
+    return () => window.clearInterval(id);
+  }, []);
+  return now;
+}
+
+interface Cell {
+  label: string;
+  value: React.ReactNode;
+  valueClassName?: string;
+}
+
+function Group({ cells }: { cells: Cell[] }) {
+  return (
+    <div className={styles.group}>
+      {cells.map((c) => (
+        <div key={c.label} className={styles.cell}>
+          <span className={styles.key}>{c.label}</span>
+          <span className={`${styles.val} ${c.valueClassName ?? ''}`}>
+            {c.value}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SysStatusCardInner() {
+  const { siteConfig } = useDocusaurusContext();
+  const buildTime = String(siteConfig.customFields?.buildTime ?? '');
+  const debugId = String(siteConfig.customFields?.debugId ?? '—');
+
+  const { data: sys } = useSysStatus();
+  const cpu = sys?.cpu ?? null;
+  const mem = sys?.mem ?? null;
+  const serverUptime = sys?.uptime ?? null;
+  const load1 = sys?.load?.[0] ?? null;
+  const disk = sys?.disk ?? null;
+  const swap = sys?.swap ?? null;
+  const lastDeploy = sys?.last_deploy ?? null;
+  const tlsExpires = sys?.tls_expires_in ?? null;
+  const ip = sys?.ip ?? null;
+  const ping = usePing();
+  const now = useNow();
+
+  const [browser, setBrowser] = useState('—');
+  const [host, setHost] = useState('—');
+  useEffect(() => {
+    setBrowser(detectBrowser(navigator.userAgent));
+    setHost(window.location.hostname);
+  }, []);
+  const cpuStr = cpu == null ? '—' : `${cpu.toFixed(1)}%`;
+  const memStr = mem == null ? '—' : `${mem.toFixed(1)}%`;
+  const pingStr = ping == null ? '—' : `${ping}ms`;
+  const uptimeStr = serverUptime == null ? '—' : formatUptimeSec(serverUptime);
+  const loadStr = load1 == null ? '—' : load1.toFixed(2);
+  const diskStr = disk == null ? '—' : `${disk.toFixed(1)}%`;
+  const swapStr = swap == null ? '—' : `${swap.toFixed(1)}%`;
+  const lastDeployStr =
+    lastDeploy == null ? '—' : formatRelative(lastDeploy, now.getTime());
+  const tlsStr = tlsExpires == null ? '—' : `${tlsExpires}d`;
+  const ipNode = ip == null ? '—' : <span title={ip}>{formatIp(ip)}</span>;
+  const mutedIfNull = (v: unknown) => (v == null ? styles.muted : undefined);
+
+  return (
+    <Card padding="1.5rem 1.25rem 1.25rem" className={styles.card}>
+      <header className={metricListStyles.head}>
+        <Icon icon="lucide:activity" className={metricListStyles.icon} />
+        <h3 className={metricListStyles.title}>
+          {translate({
+            id: 'pages.insights.sysStatus.title',
+            message: 'Runtime snapshot',
+          })}
+        </h3>
+      </header>
+
+      <div className={styles.body}>
+        <Group
+          cells={[
+            { label: 'cpu', value: cpuStr, valueClassName: mutedIfNull(cpu) },
+            { label: 'mem', value: memStr, valueClassName: mutedIfNull(mem) },
+            {
+              label: 'swap',
+              value: swapStr,
+              valueClassName: mutedIfNull(swap),
+            },
+            {
+              label: 'load',
+              value: loadStr,
+              valueClassName: mutedIfNull(load1),
+            },
+            {
+              label: 'disk',
+              value: diskStr,
+              valueClassName: mutedIfNull(disk),
+            },
+          ]}
+        />
+        <Group
+          cells={[
+            {
+              label: 'ping',
+              value: pingStr,
+              valueClassName: mutedIfNull(ping),
+            },
+            { label: 'ip', value: ipNode, valueClassName: mutedIfNull(ip) },
+            { label: 'host', value: host },
+            {
+              label: 'uptime',
+              value: uptimeStr,
+              valueClassName: mutedIfNull(serverUptime),
+            },
+            { label: 'browser', value: browser },
+          ]}
+        />
+        <Group
+          cells={[
+            {
+              label: 'last_deploy',
+              value: lastDeployStr,
+              valueClassName: mutedIfNull(lastDeploy),
+            },
+            { label: 'build_time', value: formatBuildTime(buildTime) },
+            { label: 'debug_id', value: debugId },
+            {
+              label: 'tls_expires',
+              value: tlsStr,
+              valueClassName: mutedIfNull(tlsExpires),
+            },
+            { label: 'datetime', value: formatDateTime(now) },
+          ]}
+        />
+      </div>
+
+      <span className={styles.srOnly}>
+        {translate({
+          id: 'pages.insights.sysStatus.srLabel',
+          message: 'System status overview',
+        })}
+      </span>
+    </Card>
+  );
+}
+
+export default function SysStatusCard() {
+  return (
+    <BrowserOnly fallback={<div className={styles.cardSkeleton} />}>
+      {() => <SysStatusCardInner />}
+    </BrowserOnly>
+  );
+}

--- a/src/pages/insights/index.tsx
+++ b/src/pages/insights/index.tsx
@@ -28,6 +28,7 @@ import Sparkline from './_components/Sparkline';
 import MetricList from './_components/MetricList';
 import metricListStyles from './_components/MetricList.module.css';
 import UptimeSection from './_components/UptimeSection';
+import SysStatusCard from './_components/SysStatusCard';
 import styles from './styles.module.css';
 
 countries.registerLocale(countriesEn);
@@ -385,6 +386,7 @@ export default function Insights(): ReactNode {
         <HeroGrid range={range} />
         <PageviewsChart range={range} />
         <MetricsGrid range={range} />
+        <SysStatusCard />
         <UptimeSection />
       </PageContent>
     </Layout>


### PR DESCRIPTION
## Summary

Adds a new **Runtime snapshot** card to the `/insights` page — a 15-field terminal-style status panel showing live server metrics, client/connection info, and build lifecycle.

Sits between `MetricsGrid` and `UptimeSection` on the Insights page, in a 3×5 grid layout where rows 1/4/5 form coherent themes:

```
cpu   2.3%       ping     182ms             last_deploy   6h ago
mem   50.0%      ip       192.69.93.46      build_time    2026-05-03
swap  0.0%       host     localhost         debug_id      LAI#F135CC38.3903
load  0.03       uptime   18d 4h            tls_expires   82d
disk  43.7%      browser  Chrome            datetime      2026-05-03 03:38:42
```

## What's in this PR

**Frontend only.** The companion server-side endpoint (Node service + Caddy reverse-proxy) is deployed manually on the VPS — see "Backend dependency" below.

- `src/hooks/useSysStatus.ts` — new hook that polls `https://lailai.one/api/sys` every 8s with `cache: 'no-store'`
- `src/pages/insights/_components/SysStatusCard.tsx` — the card component, with format helpers for uptime, relative time, IPv6 middle-truncation, and ISO date
- `src/pages/insights/_components/SysStatusCard.module.css` — monospace grid, terminal-feel background pattern, responsive collapse to 2/1 columns
- `src/pages/insights/index.tsx` — render the card after `MetricsGrid`
- `docusaurus.config.ts` — inject `BUILD_TIME` (ISO timestamp) and `DEBUG_ID` (git short SHA + commit count) into `customFields` at build time
- `i18n/zh-Hans/code.json` — `pages.insights.sysStatus.title: 运行时快照`

## Field breakdown

| Field | Source | Updates |
|---|---|---|
| cpu / mem / swap / load / disk | `/api/sys` (server reads /proc) | every 8s |
| ping | client `fetch HEAD` to analytics endpoint | every 8s |
| ip | `/api/sys` (server reads `X-Forwarded-For`, per-request) | every 8s |
| host | `window.location.hostname` | once on mount |
| uptime | `/api/sys` (server `os.uptime()`) | every 8s |
| browser | `navigator.userAgent` parse | once on mount |
| last_deploy | `/api/sys` (server reads `index.html` mtime) | every 8s |
| build_time | `customFields.buildTime` (build-time inject) | static per bundle |
| debug_id | `customFields.debugId` (build-time inject) | static per bundle |
| tls_expires | `/api/sys` (Node `crypto.X509Certificate` parse) | every 8s |
| datetime | `new Date()` | every 1s |

## Design choices

- **Monochrome**: removed all threshold-based color coding. The only color used is `.muted` for null/error states. Reasoning: a card full of green text reads as decoration; reserving color for *signals* keeps the design intentional.
- **Row themes**: orderings are chosen so row 1 (cpu/ping/last_deploy) forms a "LIVE" trio, row 4 (load/uptime/tls_expires) forms a "DURATION/COUNTDOWN" trio, row 5 (disk/browser/datetime) forms a static "ANCHOR" trio.
- **ISO 8601 dates**: switched from `2026/05/03` to `2026-05-03` for both `build_time` and `datetime` — matches the engineering aesthetic of the rest of the card.

## Backend dependency

The card depends on a self-hosted endpoint at `https://lailai.one/api/sys` returning:

\`\`\`jsonc
{
  "cpu": 2.3, "mem": 50.0, "mem_used_mb": 1955, "mem_total_mb": 3911,
  "uptime": 1568079, "load": [0.16, 0.09, 0.04], "cores": 4,
  "disk": 43.7, "swap": 0,
  "last_deploy": 1746234567569, "tls_expires_in": 82,
  "ip": "203.0.113.42", "ts": 1746234588438
}
\`\`\`

Implemented as a small Node 18+ service at `/opt/lailai-sys-api/server.mjs` (zero npm deps, only Node built-ins) running under systemd, reverse-proxied by Caddy with `Cache-Control: private, max-age=2` (so per-request IPs aren't shared by intermediaries). Falls back gracefully to muted "—" cells if the endpoint is unreachable, so degraded state is acceptable.

## Test plan

- [x] `npm run check` (i18n + prettier + tsc) passes
- [x] Verified card renders correctly in dev server via preview tools
- [x] Verified all 15 fields populate with real data (no `null` after backend swap was enabled)
- [x] Verified ISO date format `2026-05-03 03:38:42` displays correctly
- [x] Verified `cpu` shows 1-decimal precision (e.g. `2.3%` instead of integer-rounded `2%`)
- [x] Confirmed no console errors on stable load
- [ ] Reviewer: pull and check responsive collapse at <768px and <480px viewports
- [ ] Reviewer: confirm cell content remains readable when `swap` is null on a no-swap host (graceful "—" muted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)