### PR TITLE
Add monthly calendar card to blog sidebar

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -309,6 +309,15 @@
   "blog.sidebar.tags.title": {
     "message": "热门标签"
   },
+  "blog.sidebar.calendar.prev": {
+    "message": "上个月"
+  },
+  "blog.sidebar.calendar.next": {
+    "message": "下个月"
+  },
+  "blog.sidebar.calendar.empty": {
+    "message": "暂无文章"
+  },
   "blog.sidebar.feed.rss": {
     "message": "RSS 订阅"
   },

--- a/src/theme/BlogShared/Calendar.tsx
+++ b/src/theme/BlogShared/Calendar.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import { Icon } from '@iconify/react';
+import { translate } from '@docusaurus/Translate';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Card from '@site/src/components/laikit/Card';
+import { getAllBlogItems } from '@site/src/utils/blogData';
+import styles from './styles.module.css';
+
+type CalPost = {
+  title: string;
+  permalink: string;
+  date: string;
+  dateKey: string;
+};
+
+type Cell = {
+  y: number;
+  m: number;
+  d: number;
+  dateKey: string;
+  inMonth: boolean;
+};
+
+function pad(n: number) {
+  return String(n).padStart(2, '0');
+}
+
+function toDateKey(y: number, m: number, d: number) {
+  return `${y}-${pad(m + 1)}-${pad(d)}`;
+}
+
+function daysInMonth(y: number, m: number) {
+  return new Date(y, m + 1, 0).getDate();
+}
+
+function shiftMonth(y: number, m: number, delta: number) {
+  const date = new Date(y, m + delta, 1);
+  return { y: date.getFullYear(), m: date.getMonth() };
+}
+
+export default function CalendarCard() {
+  const { i18n } = useDocusaurusContext();
+  const locale = i18n.currentLocale;
+
+  const posts = useMemo<CalPost[]>(() => {
+    return getAllBlogItems()
+      .map((it): CalPost | null => {
+        const title = it.title ?? it.metadata?.title;
+        const date = it.date ?? it.metadata?.date;
+        const permalink = it.permalink ?? it.metadata?.permalink;
+        if (!title || !date || !permalink) return null;
+        return { title, date, permalink, dateKey: date.slice(0, 10) };
+      })
+      .filter((x): x is CalPost => x !== null)
+      .sort((a, b) => (a.date < b.date ? 1 : -1));
+  }, []);
+
+  const postsByDate = useMemo(() => {
+    const map = new Map<string, CalPost[]>();
+    posts.forEach((p) => {
+      const arr = map.get(p.dateKey);
+      if (arr) arr.push(p);
+      else map.set(p.dateKey, [p]);
+    });
+    return map;
+  }, [posts]);
+
+  const todayKey = useMemo(() => {
+    const now = new Date();
+    return toDateKey(now.getFullYear(), now.getMonth(), now.getDate());
+  }, []);
+
+  const initial = useMemo(() => {
+    const now = new Date();
+    return { y: now.getFullYear(), m: now.getMonth() };
+  }, []);
+  const [view, setView] = useState(initial);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const monthLabel = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        year: 'numeric',
+        month: 'long',
+      }).format(new Date(view.y, view.m, 1)),
+    [locale, view]
+  );
+
+  const weekdayLabels = useMemo(() => {
+    const fmt = new Intl.DateTimeFormat(locale, { weekday: 'narrow' });
+    // 2024-01-07 is a Sunday — use it as anchor for Sunday-first ordering.
+    return Array.from({ length: 7 }, (_, i) =>
+      fmt.format(new Date(2024, 0, 7 + i))
+    );
+  }, [locale]);
+
+  const cells = useMemo<Cell[]>(() => {
+    const firstDow = new Date(view.y, view.m, 1).getDay();
+    const dim = daysInMonth(view.y, view.m);
+    const prev = shiftMonth(view.y, view.m, -1);
+    const next = shiftMonth(view.y, view.m, 1);
+    const prevDim = daysInMonth(prev.y, prev.m);
+
+    const arr: Cell[] = [];
+    for (let i = firstDow - 1; i >= 0; i--) {
+      const d = prevDim - i;
+      arr.push({
+        y: prev.y,
+        m: prev.m,
+        d,
+        dateKey: toDateKey(prev.y, prev.m, d),
+        inMonth: false,
+      });
+    }
+    for (let d = 1; d <= dim; d++) {
+      arr.push({
+        y: view.y,
+        m: view.m,
+        d,
+        dateKey: toDateKey(view.y, view.m, d),
+        inMonth: true,
+      });
+    }
+    let nd = 1;
+    while (arr.length < 42) {
+      arr.push({
+        y: next.y,
+        m: next.m,
+        d: nd,
+        dateKey: toDateKey(next.y, next.m, nd),
+        inMonth: false,
+      });
+      nd += 1;
+    }
+    return arr;
+  }, [view]);
+
+  const visiblePosts = useMemo(() => {
+    if (selected) return postsByDate.get(selected) ?? [];
+    const prefix = `${view.y}-${pad(view.m + 1)}`;
+    return posts.filter((p) => p.dateKey.startsWith(prefix));
+  }, [posts, postsByDate, selected, view]);
+
+  const goPrev = () => {
+    setView((v) => shiftMonth(v.y, v.m, -1));
+    setSelected(null);
+  };
+  const goNext = () => {
+    setView((v) => shiftMonth(v.y, v.m, 1));
+    setSelected(null);
+  };
+
+  const handlePick = (cell: Cell) => {
+    const has = postsByDate.has(cell.dateKey);
+    if (!has) return;
+    if (!cell.inMonth) {
+      setView({ y: cell.y, m: cell.m });
+    }
+    setSelected((s) => (s === cell.dateKey ? null : cell.dateKey));
+  };
+
+  const formatDayLabel = (key: string) => key.slice(5).replace('-', '/');
+
+  return (
+    <Card>
+      <div className={styles.calendarHeader}>
+        <span className={styles.calendarTitleAccent} />
+        <span className={styles.calendarTitle}>{monthLabel}</span>
+        <div className={styles.calendarNav}>
+          <button
+            type="button"
+            className={styles.calendarNavBtn}
+            onClick={goPrev}
+            aria-label={translate({
+              id: 'blog.sidebar.calendar.prev',
+              message: 'Previous month',
+            })}
+          >
+            <Icon icon="lucide:chevron-left" width="1em" height="1em" />
+          </button>
+          <button
+            type="button"
+            className={styles.calendarNavBtn}
+            onClick={goNext}
+            aria-label={translate({
+              id: 'blog.sidebar.calendar.next',
+              message: 'Next month',
+            })}
+          >
+            <Icon icon="lucide:chevron-right" width="1em" height="1em" />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.calendarWeekdays}>
+        {weekdayLabels.map((label, i) => (
+          <span key={i} className={styles.calendarWeekday}>
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div className={styles.calendarGrid}>
+        {cells.map((cell) => {
+          const has = postsByDate.has(cell.dateKey);
+          const isSelected = selected === cell.dateKey;
+          const isToday = cell.dateKey === todayKey;
+          return (
+            <button
+              key={`${cell.y}-${cell.m}-${cell.d}`}
+              type="button"
+              onClick={() => handlePick(cell)}
+              disabled={!has}
+              className={clsx(styles.calendarCell, {
+                [styles.calendarCellMuted]: !cell.inMonth,
+                [styles.calendarCellHasPost]: has,
+                [styles.calendarCellSelected]: isSelected,
+                [styles.calendarCellToday]: isToday,
+              })}
+            >
+              <span className={styles.calendarCellNum}>{cell.d}</span>
+              {has && <span className={styles.calendarCellDot} />}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className={styles.calendarDivider} />
+
+      {visiblePosts.length === 0 ? (
+        <div className={styles.calendarEmpty}>
+          {translate({
+            id: 'blog.sidebar.calendar.empty',
+            message: 'No posts',
+          })}
+        </div>
+      ) : (
+        <ul className={styles.calendarPostList}>
+          {visiblePosts.map((post) => (
+            <li key={post.permalink} className={styles.calendarPostItem}>
+              <Link to={post.permalink} className={styles.calendarPostLink}>
+                <span className={styles.calendarPostTitle}>{post.title}</span>
+                <span className={styles.calendarPostDate}>
+                  {formatDayLabel(post.dateKey)}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}

--- a/src/theme/BlogShared/Scaffold.tsx
+++ b/src/theme/BlogShared/Scaffold.tsx
@@ -17,6 +17,7 @@ import {
   useAnalytics,
   type ChipItem,
 } from './Components';
+import CalendarCard from './Calendar';
 import styles from './styles.module.css';
 
 type PopularTagItem = ChipItem & {
@@ -349,6 +350,7 @@ export default function BlogScaffold({
             ) : (
               <>
                 <InfoCard />
+                <CalendarCard />
                 <StatsCard />
                 <FeedCard />
                 <TagsCard />

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -437,6 +437,212 @@
   border-color: var(--ifm-color-primary);
 }
 
+.calendarHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.calendarTitleAccent {
+  display: inline-block;
+  width: 3px;
+  height: 1rem;
+  border-radius: 2px;
+  background: var(--ifm-color-primary);
+  flex-shrink: 0;
+}
+
+.calendarTitle {
+  font-weight: 700;
+  line-height: 1;
+  font-size: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.calendarNav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.15rem;
+}
+
+.calendarNavBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+
+.calendarNavBtn:hover {
+  color: var(--ifm-color-primary);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.calendarWeekdays,
+.calendarGrid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+
+.calendarWeekdays {
+  margin-bottom: 0.35rem;
+}
+
+.calendarWeekday {
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+  padding: 0.3rem 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.calendarGrid {
+  row-gap: 0.15rem;
+}
+
+.calendarCell {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1 / 1;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: var(--ifm-font-color-base);
+  cursor: default;
+  font-variant-numeric: tabular-nums;
+}
+
+.calendarCellNum {
+  position: relative;
+  z-index: 1;
+  font-size: 0.88rem;
+  line-height: 1;
+}
+
+.calendarCellMuted {
+  color: var(--ifm-color-emphasis-400);
+}
+
+.calendarCellHasPost {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.calendarCellHasPost:hover .calendarCellNum {
+  color: var(--ifm-color-primary);
+}
+
+.calendarCellDot {
+  position: absolute;
+  bottom: 0.32rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--ifm-color-primary);
+  transition:
+    width 160ms ease,
+    background 160ms ease;
+}
+
+.calendarCellToday .calendarCellNum {
+  color: var(--ifm-color-primary);
+}
+
+.calendarCellSelected .calendarCellNum {
+  color: var(--ifm-color-primary);
+}
+
+.calendarCellSelected .calendarCellDot {
+  width: 12px;
+  border-radius: 2px;
+}
+
+.calendarDivider {
+  height: 1px;
+  background: var(--ifm-color-emphasis-200);
+  margin: 0.85rem 0 0.5rem;
+}
+
+.calendarEmpty {
+  padding: 0.75rem 0.25rem;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.85rem;
+}
+
+.calendarPostList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: calc(3 * 2.6rem);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.calendarPostList::-webkit-scrollbar {
+  width: 4px;
+}
+
+.calendarPostList::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-300);
+  border-radius: 4px;
+}
+
+.calendarPostItem {
+  margin: 0;
+}
+
+.calendarPostLink {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.25rem;
+  height: 2.6rem;
+  color: var(--ifm-font-color-base);
+  text-decoration: none !important;
+  border-bottom: 1px dashed var(--ifm-color-emphasis-200);
+}
+
+.calendarPostItem:last-child .calendarPostLink {
+  border-bottom: none;
+}
+
+.calendarPostLink:hover {
+  color: var(--ifm-color-primary);
+}
+
+.calendarPostTitle {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.92rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.calendarPostDate {
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  color: var(--ifm-color-emphasis-600);
+  font-variant-numeric: tabular-nums;
+}
+
 .tocContainer {
   position: sticky;
   top: 5rem;


### PR DESCRIPTION
## Summary
- 在博客侧边栏新增"万年日历"卡片：6×7 周日起首网格，相邻月份日期淡化，文章日带主题色圆点
- 点击有文章的日期过滤当日列表（无选中时展示当月），列表上限 3 篇、超出滚动
- 选中态改为极简"主题色文字 + 圆角小横条"标记，避免大色块圆，与侧边栏其他卡片观感一致

## Test plan
- [x] 桌面宽度下侧边栏正常显示日历卡片
- [x] 周序为 `日 一 二 三 四 五 六`，永远 42 格
- [x] 非本月日期淡化，无文章日期不可点击
- [x] 点击有文章日期切换为当日列表；6 篇月份内列表可滚动
- [x] 切月不再触发文字渐变动画

🤖 Generated with [Claude Code](https://claude.com/claude-code)