### PR TITLE
Refresh blog sidebar and home info card

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -276,20 +276,8 @@
   "blog.sidebar.toc.title": {
     "message": "目录"
   },
-  "blog.sidebar.info.location": {
-    "message": "位置"
-  },
   "blog.sidebar.info.locationValue": {
     "message": "中国杭州"
-  },
-  "blog.sidebar.info.localTime": {
-    "message": "本地时间"
-  },
-  "blog.sidebar.info.fingerprint": {
-    "message": "GPG 指纹"
-  },
-  "blog.sidebar.info.title": {
-    "message": "信息"
   },
   "blog.sidebar.stats.posts": {
     "message": "文章"
@@ -393,12 +381,6 @@
   },
   "home.bento.connect": {
     "message": "联系"
-  },
-  "home.bento.latestPost": {
-    "message": "最新文章"
-  },
-  "home.bento.noPosts": {
-    "message": "暂无文章。"
   },
   "home.blog.empty": {
     "message": "暂无文章，敬请期待更多内容..."

--- a/src/pages/_components/Bento/index.tsx
+++ b/src/pages/_components/Bento/index.tsx
@@ -1,13 +1,10 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import Link from '@docusaurus/Link';
 import { translate } from '@docusaurus/Translate';
 import clsx from 'clsx';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { Icon } from '@iconify/react';
 import { COMMUNITY_LIST } from '@site/src/data/community';
-import { getRecentBlogPosts } from '@site/src/utils/blogData';
-import { formatBeijingDate } from '@site/src/utils/format';
 import Card from '@site/src/components/laikit/Card';
 import styles from './styles.module.css';
 
@@ -49,7 +46,6 @@ function useTypewriter(words: string[]) {
 }
 
 export default function Bento() {
-  const { i18n } = useDocusaurusContext();
   const navItems = [
     {
       title: translate({
@@ -148,14 +144,35 @@ export default function Bento() {
     },
     { article: roleArticle }
   );
-  const latestPost = useMemo(() => getRecentBlogPosts(1)[0] ?? null, []);
-  const latestPostDate = latestPost
-    ? formatBeijingDate(latestPost.date, i18n.currentLocale, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      })
-    : '';
+  const localTime = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Shanghai',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date());
+  const infoItems = [
+    {
+      key: 'location',
+      value: translate({
+        id: 'blog.sidebar.info.locationValue',
+        message: 'Hangzhou, China',
+      }),
+      icon: 'lucide:map-pin',
+      href: 'https://maps.app.goo.gl/pjqPSMzrVqRcEM6J8',
+    },
+    {
+      key: 'time',
+      value: `${localTime} (UTC+08:00)`,
+      icon: 'lucide:clock',
+      href: 'https://time.is/UTC+8',
+    },
+    {
+      key: 'fingerprint',
+      value: '91A7 EF5A 1391 223E',
+      icon: 'lucide:key-round',
+      href: 'https://github.com/lailai0916.gpg',
+    },
+  ];
 
   return (
     <section className={styles.hero}>
@@ -222,34 +239,17 @@ export default function Bento() {
             ))}
           </div>
         </Card>
-        <Card className={styles.cardLatestPost} padding="1.25rem">
-          {latestPost ? (
-            <Link to={latestPost.permalink} className={styles.latestPostLink}>
-              <div className={styles.latestPostHead}>
-                <span className={styles.latestPostLabel}>
-                  {translate({
-                    id: 'home.bento.latestPost',
-                    message: 'Latest Post',
-                  })}
-                </span>
-              </div>
-              <p className={styles.latestPostTitle}>{latestPost.title}</p>
-              <p className={styles.latestPostMeta}>
-                <Icon
-                  icon="lucide:calendar"
-                  className={styles.latestPostMetaIcon}
-                />
-                <span>{latestPostDate}</span>
-              </p>
-            </Link>
-          ) : (
-            <div className={styles.latestPostEmpty}>
-              {translate({
-                id: 'home.bento.noPosts',
-                message: 'No posts yet.',
-              })}
-            </div>
-          )}
+        <Card className={styles.cardInfo} padding="1.25rem">
+          <ul className={styles.infoList}>
+            {infoItems.map((item) => (
+              <li key={item.key} className={styles.infoRow}>
+                <Icon icon={item.icon} className={styles.infoRowIcon} />
+                <Link href={item.href} className={styles.infoRowValue}>
+                  {item.value}
+                </Link>
+              </li>
+            ))}
+          </ul>
         </Card>
       </div>
     </section>

--- a/src/pages/_components/Bento/styles.module.css
+++ b/src/pages/_components/Bento/styles.module.css
@@ -202,7 +202,7 @@
 }
 
 .cardSocial {
-  grid-column: 1 / span 2;
+  grid-column: 3 / span 2;
   grid-row: 3;
   display: flex;
   align-items: center;
@@ -239,70 +239,50 @@
   color: var(--ifm-color-primary);
 }
 
-.cardLatestPost {
-  grid-column: 3 / span 2;
+.cardInfo {
+  grid-column: 1 / span 2;
   grid-row: 3;
 }
 
-.latestPostLink {
+.infoList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.55rem;
   height: 100%;
-  text-decoration: none !important;
-  color: inherit;
+  justify-content: space-evenly;
 }
 
-.latestPostLink:hover {
-  color: inherit;
-}
-
-.latestPostHead {
+.infoRow {
   display: flex;
   align-items: center;
+  gap: 0.7rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.3;
 }
 
-.latestPostLabel {
-  font-size: 0.72rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.infoRowIcon {
+  font-size: 1.05rem;
+  flex-shrink: 0;
   color: var(--ifm-color-emphasis-600);
 }
 
-.latestPostTitle {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.4;
-  color: var(--ifm-color-emphasis-900);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+.infoRowValue {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: var(--ifm-color-emphasis-900);
+  text-decoration: none !important;
+  transition: color 160ms ease;
 }
 
-.latestPostMeta {
-  margin: 0;
-  margin-top: auto;
-  display: flex;
-  align-items: center;
-  gap: 0.35rem;
-  font-size: 0.8rem;
-  font-weight: 500;
-  line-height: 1.3;
-  color: var(--ifm-color-emphasis-800);
-}
-
-.latestPostMetaIcon {
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-500);
-}
-
-.latestPostEmpty {
-  font-size: 0.9rem;
-  color: var(--ifm-color-emphasis-700);
+.infoRowValue:hover {
+  color: var(--ifm-color-primary);
 }
 
 @media (max-width: 768px) {
@@ -339,7 +319,7 @@
     grid-row: auto;
   }
 
-  .cardLatestPost {
+  .cardInfo {
     grid-column: span 2;
     grid-row: auto;
   }
@@ -365,7 +345,7 @@
 
   .cardMainLink,
   .cardSocial,
-  .cardLatestPost,
+  .cardInfo,
   .cardNav {
     grid-column: span 1;
     grid-row: span 1;

--- a/src/theme/BlogShared/Scaffold.tsx
+++ b/src/theme/BlogShared/Scaffold.tsx
@@ -43,6 +43,7 @@ function AuthorCard() {
           className={styles.authorAvatar}
         />
         <div className={styles.authorName}>{author.name}</div>
+        <span className={styles.authorAccent} aria-hidden="true" />
         <div className={styles.authorDesc}>{author.title}</div>
       </div>
     </BlogCard>
@@ -96,80 +97,6 @@ function TocCard({ toc }: { toc: readonly TOCItem[] }) {
         </ul>
       </BlogCard>
     </div>
-  );
-}
-
-function InfoCard() {
-  const timeZone = 'Asia/Shanghai';
-  const localTime = new Intl.DateTimeFormat('en-GB', {
-    timeZone,
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  }).format(new Date());
-  const infoItems = [
-    {
-      key: 'location',
-      label: translate({
-        id: 'blog.sidebar.info.location',
-        message: 'Location',
-      }),
-      value: translate({
-        id: 'blog.sidebar.info.locationValue',
-        message: 'Hangzhou, China',
-      }),
-      icon: 'lucide:map-pin',
-      href: 'https://maps.app.goo.gl/pjqPSMzrVqRcEM6J8',
-    },
-    {
-      key: 'time',
-      label: translate({
-        id: 'blog.sidebar.info.localTime',
-        message: 'Local Time',
-      }),
-      value: `${localTime} (UTC+08:00)`,
-      icon: 'lucide:clock',
-      href: 'https://time.is/UTC+8',
-    },
-    {
-      key: 'fingerprint',
-      label: translate({
-        id: 'blog.sidebar.info.fingerprint',
-        message: 'GPG Fingerprint',
-      }),
-      value: '91A7 EF5A 1391 223E',
-      icon: 'lucide:key-round',
-      href: 'https://github.com/lailai0916.gpg',
-    },
-  ];
-
-  return (
-    <BlogCard
-      title={translate({
-        id: 'blog.sidebar.info.title',
-        message: 'Information',
-      })}
-    >
-      <div className={styles.infoCard}>
-        {infoItems.map((item) => (
-          <Link key={item.key} href={item.href} className={styles.infoItem}>
-            <span className={styles.infoItemIcon}>
-              <Icon icon={item.icon} width="1.1em" height="1.1em" />
-            </span>
-            <span className={styles.infoItemText}>
-              <span className={styles.infoItemLabel}>{item.label}</span>
-              <span className={styles.infoItemValue}>{item.value}</span>
-            </span>
-            <Icon
-              icon="lucide:chevron-right"
-              width="0.95em"
-              height="0.95em"
-              className={styles.infoItemArrow}
-            />
-          </Link>
-        ))}
-      </div>
-    </BlogCard>
   );
 }
 
@@ -278,21 +205,27 @@ function TagsCard() {
 function FeedCard() {
   const feeds = [
     {
-      label: translate({
+      name: 'RSS',
+      icon: 'lucide:rss',
+      ariaLabel: translate({
         id: 'blog.sidebar.feed.rss',
         message: 'RSS Feed',
       }),
       href: useBaseUrl('/blog/rss.xml', { absolute: true }),
     },
     {
-      label: translate({
+      name: 'Atom',
+      icon: 'lucide:atom',
+      ariaLabel: translate({
         id: 'blog.sidebar.feed.atom',
         message: 'Atom Feed',
       }),
       href: useBaseUrl('/blog/atom.xml', { absolute: true }),
     },
     {
-      label: translate({
+      name: 'JSON',
+      icon: 'lucide:braces',
+      ariaLabel: translate({
         id: 'blog.sidebar.feed.json',
         message: 'JSON Feed',
       }),
@@ -307,14 +240,21 @@ function FeedCard() {
         message: 'Subscribe',
       })}
     >
-      <div className={styles.feedButtonGroup}>
+      <div className={styles.feedGrid}>
         {feeds.map((feed) => (
           <Link
             key={feed.href}
             href={feed.href}
-            className={clsx(styles.tagChip, styles.postInlineTag)}
+            aria-label={feed.ariaLabel}
+            className={styles.feedTile}
           >
-            {feed.label}
+            <Icon
+              icon={feed.icon}
+              width="1.2em"
+              height="1.2em"
+              className={styles.feedTileIcon}
+            />
+            <span className={styles.feedTileLabel}>{feed.name}</span>
           </Link>
         ))}
       </div>
@@ -349,11 +289,10 @@ export default function BlogScaffold({
               <TocCard toc={toc} />
             ) : (
               <>
-                <InfoCard />
                 <CalendarCard />
                 <StatsCard />
-                <FeedCard />
                 <TagsCard />
+                <FeedCard />
               </>
             )}
           </>

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -49,8 +49,8 @@
   display: flex;
   align-items: center;
   flex-direction: column;
-  gap: 0.5rem;
-  padding: 1rem 0;
+  text-align: center;
+  padding: 0.75rem 0 0.5rem;
 }
 
 .authorAvatar {
@@ -58,92 +58,36 @@
   height: 96px;
   border-radius: 50%;
   object-fit: cover;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.18);
+  background: var(--ifm-card-background-color);
+  padding: 4px;
+  box-shadow:
+    0 0 0 1px var(--ifm-color-emphasis-200),
+    0 8px 22px rgba(0, 0, 0, 0.10);
 }
 
 .authorName {
+  margin-top: 0.95rem;
+  font-size: 1.5rem;
   font-weight: 700;
-  font-size: 2rem;
+  letter-spacing: -0.01em;
+  line-height: 1.1;
+}
+
+.authorAccent {
+  display: block;
+  width: 24px;
+  height: 2px;
+  margin: 0.7rem 0 0.55rem;
+  border-radius: 2px;
+  background: var(--ifm-color-primary);
 }
 
 .authorDesc {
-  color: var(--ifm-color-emphasis-700);
-  font-size: 0.9rem;
-}
-
-.infoCard {
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-}
-
-.infoItem {
-  display: grid;
-  grid-template-columns: 2rem minmax(0, 1fr) auto;
-  gap: 0.7rem;
-  align-items: center;
-  padding: 0.62rem 0.7rem;
-  border-radius: 12px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  color: var(--ifm-font-color-base);
-  text-decoration: none !important;
-  transition:
-    border-color 160ms ease,
-    background-color 160ms ease,
-    transform 160ms ease,
-    box-shadow 160ms ease;
-}
-
-.infoItem:hover {
-  color: inherit;
-  border-color: var(--ifm-color-primary);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
-}
-
-.infoItemIcon {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 10px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--ifm-color-primary);
-  background: var(--ifm-card-background-color);
-  border: 1px solid var(--ifm-color-emphasis-200);
-  flex-shrink: 0;
-}
-
-.infoItemText {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.14rem;
-}
-
-.infoItemLabel {
-  font-size: 0.72rem;
-  line-height: 1.2;
-  letter-spacing: 0.07em;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--ifm-color-emphasis-700);
-}
-
-.infoItemValue {
-  font-size: 0.92rem;
-  line-height: 1.25;
-  font-weight: 600;
-  overflow-wrap: anywhere;
-}
-
-.infoItemArrow {
-  color: var(--ifm-color-emphasis-500);
-  transition:
-    color 160ms ease,
-    transform 160ms ease;
-}
-
-.infoItem:hover .infoItemArrow {
-  color: var(--ifm-color-primary);
 }
 
 .statsGrid {
@@ -323,10 +267,46 @@
   color: var(--ifm-color-primary);
 }
 
-.feedButtonGroup {
+.feedGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.feedTile {
   display: flex;
-  width: 100%;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.7rem 0.4rem;
+  border-radius: 12px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-card-background-color);
+  text-decoration: none !important;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.feedTile:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+  background: color-mix(in srgb, var(--ifm-color-primary) 6%, transparent);
+}
+
+.feedTileIcon {
+  flex-shrink: 0;
+}
+
+.feedTileLabel {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 .postCoverWrap {


### PR DESCRIPTION
## Summary
- 博客侧边栏重排：作者 → 万年日历 → 统计 → 热门标签 → 订阅；删除原 Information 卡片及相关 CSS / i18n（仅保留 `info.locationValue`）
- 重设计作者卡：96px 头像（双层描边 + 软阴影）、24×2px 主题色短横、全大写小字职衔
- 订阅卡改为三宫格图标磁贴（RSS / Atom / JSON），与日历/统计风格统一
- 首页 Bento 的"最新文章"卡换为 Information 卡（位置/本地时间/GPG 指纹），图标移出链接；与 Connect 卡左右互换，CTA 落在右下
- 日历选中态去掉大圆改为短横下划标记；移除导致切月文字渐变的 color transition

## Test plan
- [x] 博客列表页与文章页侧边栏渲染顺序正确
- [x] 作者卡视觉竖向居中，无报错
- [x] 订阅 3 个磁贴 hover 同步主题色，aria-label 完整
- [x] 首页 Bento 信息卡 3 行内容与侧栏 InfoCard 旧数据一致
- [x] 日历切月不再触发文字渐显

🤖 Generated with [Claude Code](https://claude.com/claude-code)