### PR TITLE
Polish blog header bits, add author selector, calendar tidy

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -318,14 +318,17 @@
   "blog.sidebar.feed.title": {
     "message": "订阅"
   },
-  "blog.menu.latest": {
-    "message": "最新"
+  "blog.menu.blog": {
+    "message": "博客"
   },
   "blog.menu.archive": {
     "message": "归档"
   },
   "blog.menu.tags": {
     "message": "标签"
+  },
+  "blog.menu.moments": {
+    "message": "动态"
   },
   "blog.menu.authors": {
     "message": "作者"
@@ -336,6 +339,9 @@
   },
   "blog.pages.tags.tagSelect": {
     "message": "标签"
+  },
+  "blog.pages.authors.authorSelect": {
+    "message": "作者"
   },
   "home.bento.nav.contest": {
     "message": "竞赛"

--- a/src/pages/blog/moments/index.tsx
+++ b/src/pages/blog/moments/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon } from '@iconify/react';
 import BlogScaffold from '@site/src/theme/BlogShared/Scaffold';
 import { BlogCard } from '@site/src/theme/BlogShared/Components';
 import { MOMENT_LIST } from '@site/src/data/moments';
@@ -12,14 +13,21 @@ export default function moments() {
   return (
     <BlogScaffold title={TITLE} description={DESCRIPTION}>
       <BlogCard>
-        <div className={styles.headerSection}>
-          <div>
+        <div className={styles.headerCard}>
+          <div className={styles.headerInfo}>
             <h1 className={styles.title}>{TITLE}</h1>
             <p className={styles.description}>{DESCRIPTION}</p>
           </div>
-          <div
-            className={styles.momentCount}
-          >{`${MOMENT_LIST.length} moments`}</div>
+          <div className={styles.countChip}>
+            <Icon
+              icon="lucide:sparkles"
+              width="0.95em"
+              height="0.95em"
+              className={styles.countChipIcon}
+            />
+            <span className={styles.countChipNumber}>{MOMENT_LIST.length}</span>
+            <span className={styles.countChipLabel}>moments</span>
+          </div>
         </div>
       </BlogCard>
       {MOMENT_LIST.map((moment) => (

--- a/src/pages/blog/moments/styles.module.css
+++ b/src/pages/blog/moments/styles.module.css
@@ -1,39 +1,62 @@
-.headerSection {
+.headerCard {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  gap: clamp(0.5rem, 2vw, 1rem);
-  padding: clamp(0.75rem, 2vw, 1rem);
-
-  background-color: var(--ifm-color-primary);
-  color: #ffffff;
-  border-radius: 8px;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-@media (max-width: 768px) {
-  .headerSection {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+.headerInfo {
+  min-width: 0;
 }
 
 .title {
-  font-size: clamp(1.5rem, 2vw + 1rem, 2rem);
+  font-size: 1.6rem;
+  font-weight: 700;
+  line-height: 1.15;
   margin: 0;
-  line-height: 1.2;
 }
 
 .description {
-  font-size: clamp(0.9rem, 0.3vw + 0.85rem, 1rem);
-  font-weight: 700;
-  opacity: 0.8;
-  margin: 0;
+  margin: 0.4rem 0 0;
+  font-size: 0.92rem;
+  color: var(--ifm-color-emphasis-700);
 }
 
-.momentCount {
-  font-size: clamp(1rem, 0.5vw + 0.9rem, 1.2rem);
+.countChip {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+.countChipIcon {
+  align-self: center;
+  color: var(--ifm-color-primary);
+}
+
+.countChipNumber {
   font-weight: 700;
-  opacity: 0.8;
+  font-size: 0.95rem;
+  color: var(--ifm-color-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.countChipLabel {
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 480px) {
+  .headerCard {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 
 .imageContainer {

--- a/src/theme/Blog/Pages/BlogAuthorsListPage/index.tsx
+++ b/src/theme/Blog/Pages/BlogAuthorsListPage/index.tsx
@@ -18,24 +18,24 @@ export default function BlogAuthorsListPage(props: Props): ReactNode {
   if (isOriginalLayout) return <BlogAuthorsListPageOriginal {...props} />;
 
   const { authors } = props;
+  const items = authors.flatMap((author) => {
+    if (!author.page?.permalink) {
+      return [];
+    }
+
+    return [
+      {
+        to: author.page.permalink,
+        label: author.name ?? author.key,
+        count: author.count,
+      },
+    ];
+  });
+
   return (
     <BlogScaffold title={TITLE} description={DESCRIPTION}>
-      <BlogCard title={TITLE}>
-        <TagChipList
-          items={authors.flatMap((author) => {
-            if (!author.page?.permalink) {
-              return [];
-            }
-
-            return [
-              {
-                to: author.page.permalink,
-                label: author.name ?? author.key,
-                count: author.count,
-              },
-            ];
-          })}
-        />
+      <BlogCard title={`${TITLE} (${items.length})`}>
+        <TagChipList items={items} />
       </BlogCard>
     </BlogScaffold>
   );

--- a/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
+++ b/src/theme/Blog/Pages/BlogAuthorsPostsPage/index.tsx
@@ -1,8 +1,50 @@
 import React, { type ReactNode } from 'react';
+import { translate } from '@docusaurus/Translate';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import { useTheme } from '@site/src/hooks/useTheme';
+import { loadOfficialAuthors } from '@site/src/utils/blogData';
 import BlogAuthorsPostsPageOriginal from '@theme-original/Blog/Pages/BlogAuthorsPostsPage';
 import type { Props } from '@theme/Blog/Pages/BlogAuthorsPostsPage';
 import PostsListLayout from '../../../BlogShared/PostsListLayout';
+import { BlogCard, TagChipList } from '../../../BlogShared/Components';
+
+const TITLE = translate({
+  id: 'blog.pages.authors.authorSelect',
+  message: 'Authors',
+});
+
+function AuthorSelector({ activePermalink }: { activePermalink: string }) {
+  const { i18n } = useDocusaurusContext();
+  const { currentLocale, defaultLocale } = i18n;
+  const localeKey = currentLocale === defaultLocale ? undefined : currentLocale;
+  const authors = React.useMemo(
+    () => loadOfficialAuthors(localeKey),
+    [localeKey]
+  );
+  const authorsListUrl = useBaseUrl('/blog/authors');
+
+  const items = authors.flatMap((author) => {
+    if (!author.page?.permalink) return [];
+    const isActive = author.page.permalink === activePermalink;
+    return [
+      {
+        to: isActive ? authorsListUrl : author.page.permalink,
+        label: author.name ?? author.key,
+        count: author.count,
+        active: isActive,
+      },
+    ];
+  });
+
+  if (!items.length) return null;
+
+  return (
+    <BlogCard title={`${TITLE} (${items.length})`}>
+      <TagChipList items={items} />
+    </BlogCard>
+  );
+}
 
 export default function BlogAuthorsPostsPage(props: Props): ReactNode {
   const { isOriginalLayout } = useTheme();
@@ -16,6 +58,11 @@ export default function BlogAuthorsPostsPage(props: Props): ReactNode {
       description={author.title}
       items={items}
       meta={listMetadata}
+      topSlot={
+        author.page?.permalink ? (
+          <AuthorSelector activePermalink={author.page.permalink} />
+        ) : null
+      }
     />
   );
 }

--- a/src/theme/BlogShared/Calendar.tsx
+++ b/src/theme/BlogShared/Calendar.tsx
@@ -67,11 +67,6 @@ export default function CalendarCard() {
     return map;
   }, [posts]);
 
-  const todayKey = useMemo(() => {
-    const now = new Date();
-    return toDateKey(now.getFullYear(), now.getMonth(), now.getDate());
-  }, []);
-
   const initial = useMemo(() => {
     const now = new Date();
     return { y: now.getFullYear(), m: now.getMonth() };
@@ -166,7 +161,6 @@ export default function CalendarCard() {
   return (
     <Card>
       <div className={styles.calendarHeader}>
-        <span className={styles.calendarTitleAccent} />
         <span className={styles.calendarTitle}>{monthLabel}</span>
         <div className={styles.calendarNav}>
           <button
@@ -206,7 +200,6 @@ export default function CalendarCard() {
         {cells.map((cell) => {
           const has = postsByDate.has(cell.dateKey);
           const isSelected = selected === cell.dateKey;
-          const isToday = cell.dateKey === todayKey;
           return (
             <button
               key={`${cell.y}-${cell.m}-${cell.d}`}
@@ -217,7 +210,6 @@ export default function CalendarCard() {
                 [styles.calendarCellMuted]: !cell.inMonth,
                 [styles.calendarCellHasPost]: has,
                 [styles.calendarCellSelected]: isSelected,
-                [styles.calendarCellToday]: isToday,
               })}
             >
               <span className={styles.calendarCellNum}>{cell.d}</span>

--- a/src/theme/BlogShared/Components.tsx
+++ b/src/theme/BlogShared/Components.tsx
@@ -63,7 +63,11 @@ export function BlogMenu() {
   const items = [
     {
       to: useBaseUrl('/blog'),
-      label: translate({ id: 'blog.menu.latest', message: 'Latest' }),
+      label: translate({ id: 'blog.menu.blog', message: 'Blog' }),
+    },
+    {
+      to: useBaseUrl('/blog/moments'),
+      label: translate({ id: 'blog.menu.moments', message: 'Moments' }),
     },
     {
       to: useBaseUrl('/blog/archive'),

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -69,7 +69,6 @@
   margin-top: 0.95rem;
   font-size: 1.5rem;
   font-weight: 700;
-  letter-spacing: -0.01em;
   line-height: 1.1;
 }
 
@@ -83,10 +82,8 @@
 }
 
 .authorDesc {
-  font-size: 0.78rem;
+  font-size: 0.85rem;
   font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
   color: var(--ifm-color-emphasis-700);
 }
 
@@ -154,15 +151,15 @@
 }
 
 .blogMenu {
-  display: flex;
-  align-items: stretch;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 0.35rem;
-  flex-wrap: wrap;
 }
 
 .blogMenuItem {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   padding: 0.35rem 0.6rem;
   border-radius: 8px;
   border: 1px solid var(--ifm-color-emphasis-200);
@@ -256,6 +253,7 @@
   color: var(--ifm-color-emphasis-700);
   font-size: 0.9rem;
   white-space: nowrap;
+  font-family: var(--ifm-font-family-monospace);
 }
 
 .recentLink {
@@ -424,15 +422,6 @@
   margin-bottom: 0.85rem;
 }
 
-.calendarTitleAccent {
-  display: inline-block;
-  width: 3px;
-  height: 1rem;
-  border-radius: 2px;
-  background: var(--ifm-color-primary);
-  flex-shrink: 0;
-}
-
 .calendarTitle {
   font-weight: 700;
   line-height: 1;
@@ -487,7 +476,7 @@
 }
 
 .calendarGrid {
-  row-gap: 0.15rem;
+  row-gap: 0.1rem;
 }
 
 .calendarCell {
@@ -495,7 +484,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 1 / 1;
+  aspect-ratio: 1.2 / 1;
   padding: 0;
   border: none;
   background: transparent;
@@ -508,7 +497,7 @@
 .calendarCellNum {
   position: relative;
   z-index: 1;
-  font-size: 0.88rem;
+  font-size: 0.78rem;
   line-height: 1;
 }
 
@@ -527,7 +516,7 @@
 
 .calendarCellDot {
   position: absolute;
-  bottom: 0.32rem;
+  bottom: 0.22rem;
   left: 50%;
   transform: translateX(-50%);
   width: 3px;
@@ -539,16 +528,12 @@
     background 160ms ease;
 }
 
-.calendarCellToday .calendarCellNum {
-  color: var(--ifm-color-primary);
-}
-
 .calendarCellSelected .calendarCellNum {
   color: var(--ifm-color-primary);
 }
 
 .calendarCellSelected .calendarCellDot {
-  width: 12px;
+  width: 10px;
   border-radius: 2px;
 }
 

--- a/src/utils/blogData.ts
+++ b/src/utils/blogData.ts
@@ -202,3 +202,50 @@ export function loadOfficialTags(locale?: string): TagAggregate[] {
   cachedOfficialTags.set(cacheKey, []);
   return [];
 }
+
+export type AuthorAggregate = {
+  key: string;
+  name?: string;
+  page?: { permalink: string };
+  count: number;
+};
+
+const cachedOfficialAuthors = new Map<string, AuthorAggregate[]>();
+
+export function loadOfficialAuthors(locale?: string): AuthorAggregate[] {
+  const cacheKey = getLocaleCacheKey(locale);
+  const cached = cachedOfficialAuthors.get(cacheKey);
+  if (cached) return cached;
+
+  const filePrefix = getLocaleFilePrefix(locale);
+  const basePattern = new RegExp(
+    `^\\.\/${filePrefix}blog-authors-[a-z0-9]+\\.json$`,
+    'i'
+  );
+
+  const ctx = (require as any).context(
+    '@generated/docusaurus-plugin-content-blog/default/p',
+    false,
+    /blog-authors-.*\.json$/
+  );
+  for (const key of ctx.keys()) {
+    if (!basePattern.test(key)) continue;
+    const mod = ctx(key);
+    const data = (mod && (mod.authors ?? mod.default?.authors)) as
+      | AuthorAggregate[]
+      | undefined;
+    if (Array.isArray(data)) {
+      cachedOfficialAuthors.set(cacheKey, data);
+      return data;
+    }
+  }
+
+  if (locale) {
+    const fallback = loadOfficialAuthors();
+    cachedOfficialAuthors.set(cacheKey, fallback);
+    return fallback;
+  }
+
+  cachedOfficialAuthors.set(cacheKey, []);
+  return [];
+}


### PR DESCRIPTION
## Summary
- 博客菜单：第一项 "Latest" → "Blog"；新增第 5 项 "Moments" → /blog/moments；改为 5 列等宽 grid
- 作者列表页：标题加 `(N)` 计数，与标签页风格一致
- 作者文章页：新增 AuthorSelector 顶栏，复用 `TagChipList` 实现"点击作者切换 / 再点回汇总"的交互；新增 `loadOfficialAuthors` 工具读取生成的 authors json
- Moments 页面：头部卡重做——废弃纯蓝实色块，改为标准 BlogCard + 主题色 sparkles 计数胶囊，与其他卡片同款圆角/边框/阴影
- 日历：去掉标题前的蓝色短竖线；只缩小 6×7 网格本身（1.2:1 比例 + 0.78rem 数字 + 10px 选中下划标记）；去掉今日高亮与对应未用状态
- 归档页：月-日时间改为等宽字体，便于数字对齐

## Test plan
- [x] /blog 博客菜单 5 等宽按钮，文案与跳转正确
- [x] /blog/authors 标题为 "作者 (1)"
- [x] /blog/authors/lailai 顶部出现作者选择器，当前作者高亮，点击回到汇总
- [x] /blog/moments 头部卡片为白底圆角，右侧 ✨ 4 moments 胶囊
- [x] 侧边栏日历缩小后无溢出，切月/选中行为正常
- [x] /blog/archive 月-日时间为等宽

🤖 Generated with [Claude Code](https://claude.com/claude-code)