### PR TITLE
Trim sidebar cards and lift Moments header icon

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -285,15 +285,6 @@
   "blog.sidebar.stats.words": {
     "message": "词数"
   },
-  "blog.sidebar.stats.visitors": {
-    "message": "访客"
-  },
-  "blog.sidebar.stats.views": {
-    "message": "浏览"
-  },
-  "blog.sidebar.stats.title": {
-    "message": "统计"
-  },
   "blog.sidebar.tags.title": {
     "message": "热门标签"
   },
@@ -314,9 +305,6 @@
   },
   "blog.sidebar.feed.json": {
     "message": "JSON 订阅"
-  },
-  "blog.sidebar.feed.title": {
-    "message": "订阅"
   },
   "blog.menu.blog": {
     "message": "博客"

--- a/src/pages/blog/moments/index.tsx
+++ b/src/pages/blog/moments/index.tsx
@@ -15,18 +15,19 @@ export default function moments() {
       <BlogCard>
         <div className={styles.headerCard}>
           <div className={styles.headerInfo}>
-            <h1 className={styles.title}>{TITLE}</h1>
+            <h1 className={styles.title}>
+              <Icon
+                icon="lucide:sparkles"
+                className={styles.titleIcon}
+                aria-hidden="true"
+              />
+              {TITLE}
+            </h1>
             <p className={styles.description}>{DESCRIPTION}</p>
           </div>
-          <div className={styles.countChip}>
-            <Icon
-              icon="lucide:sparkles"
-              width="0.95em"
-              height="0.95em"
-              className={styles.countChipIcon}
-            />
-            <span className={styles.countChipNumber}>{MOMENT_LIST.length}</span>
-            <span className={styles.countChipLabel}>moments</span>
+          <div className={styles.countMeta}>
+            <span className={styles.countMetaNumber}>{MOMENT_LIST.length}</span>
+            <span>moments</span>
           </div>
         </div>
       </BlogCard>

--- a/src/pages/blog/moments/styles.module.css
+++ b/src/pages/blog/moments/styles.module.css
@@ -10,10 +10,19 @@
 }
 
 .title {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
   font-size: 1.6rem;
   font-weight: 700;
   line-height: 1.15;
   margin: 0;
+}
+
+.titleIcon {
+  font-size: 1.2rem;
+  color: var(--ifm-color-primary);
+  flex-shrink: 0;
 }
 
 .description {
@@ -22,34 +31,25 @@
   color: var(--ifm-color-emphasis-700);
 }
 
-.countChip {
+.countMeta {
   flex-shrink: 0;
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 0.35rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid var(--ifm-color-emphasis-200);
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-700);
   font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-700);
   line-height: 1;
 }
 
-.countChipIcon {
-  align-self: center;
+.countMetaIcon {
   color: var(--ifm-color-primary);
+  flex-shrink: 0;
 }
 
-.countChipNumber {
+.countMetaNumber {
   font-weight: 700;
-  font-size: 0.95rem;
-  color: var(--ifm-color-primary);
+  color: var(--ifm-color-emphasis-900);
   font-variant-numeric: tabular-nums;
-}
-
-.countChipLabel {
-  letter-spacing: 0.04em;
 }
 
 @media (max-width: 480px) {

--- a/src/theme/BlogShared/Scaffold.tsx
+++ b/src/theme/BlogShared/Scaffold.tsx
@@ -14,7 +14,6 @@ import {
   BlogCard,
   BlogMenu,
   TagChipList,
-  useAnalytics,
   type ChipItem,
 } from './Components';
 import CalendarCard from './Calendar';
@@ -102,7 +101,6 @@ function TocCard({ toc }: { toc: readonly TOCItem[] }) {
 
 function StatsCard() {
   const { i18n } = useDocusaurusContext();
-  const { analytics, status } = useAnalytics();
   const readingMinutes = Math.round(
     getAllPostMetadata().reduce((sum, meta) => sum + (meta.readingTime ?? 0), 0)
   );
@@ -123,31 +121,39 @@ function StatsCard() {
       icon: 'lucide:file-text',
       value: readingMinutes * 200,
     },
+  ];
+  const feeds = [
     {
-      label: translate({
-        id: 'blog.sidebar.stats.visitors',
-        message: 'Visitors',
+      name: 'RSS',
+      icon: 'lucide:rss',
+      ariaLabel: translate({
+        id: 'blog.sidebar.feed.rss',
+        message: 'RSS Feed',
       }),
-      icon: 'lucide:users',
-      value: status === 'success' ? (analytics.visitors ?? '–') : '–',
+      href: useBaseUrl('/blog/rss.xml', { absolute: true }),
     },
     {
-      label: translate({
-        id: 'blog.sidebar.stats.views',
-        message: 'Views',
+      name: 'Atom',
+      icon: 'lucide:atom',
+      ariaLabel: translate({
+        id: 'blog.sidebar.feed.atom',
+        message: 'Atom Feed',
       }),
-      icon: 'lucide:eye',
-      value: status === 'success' ? (analytics.pageviews ?? '–') : '–',
+      href: useBaseUrl('/blog/atom.xml', { absolute: true }),
+    },
+    {
+      name: 'JSON',
+      icon: 'lucide:braces',
+      ariaLabel: translate({
+        id: 'blog.sidebar.feed.json',
+        message: 'JSON Feed',
+      }),
+      href: useBaseUrl('/blog/feed.json', { absolute: true }),
     },
   ];
 
   return (
-    <BlogCard
-      title={translate({
-        id: 'blog.sidebar.stats.title',
-        message: 'Statistics',
-      })}
-    >
+    <BlogCard>
       <div className={styles.statsGrid}>
         {statsItems.map((item) => (
           <div key={item.label} className={styles.statTile}>
@@ -163,6 +169,24 @@ function StatsCard() {
                 : item.value}
             </span>
           </div>
+        ))}
+      </div>
+      <div className={styles.feedGrid}>
+        {feeds.map((feed) => (
+          <Link
+            key={feed.href}
+            href={feed.href}
+            aria-label={feed.ariaLabel}
+            className={styles.feedTile}
+          >
+            <Icon
+              icon={feed.icon}
+              width="1.2em"
+              height="1.2em"
+              className={styles.feedTileIcon}
+            />
+            <span className={styles.feedTileLabel}>{feed.name}</span>
+          </Link>
         ))}
       </div>
     </BlogCard>
@@ -202,66 +226,6 @@ function TagsCard() {
   );
 }
 
-function FeedCard() {
-  const feeds = [
-    {
-      name: 'RSS',
-      icon: 'lucide:rss',
-      ariaLabel: translate({
-        id: 'blog.sidebar.feed.rss',
-        message: 'RSS Feed',
-      }),
-      href: useBaseUrl('/blog/rss.xml', { absolute: true }),
-    },
-    {
-      name: 'Atom',
-      icon: 'lucide:atom',
-      ariaLabel: translate({
-        id: 'blog.sidebar.feed.atom',
-        message: 'Atom Feed',
-      }),
-      href: useBaseUrl('/blog/atom.xml', { absolute: true }),
-    },
-    {
-      name: 'JSON',
-      icon: 'lucide:braces',
-      ariaLabel: translate({
-        id: 'blog.sidebar.feed.json',
-        message: 'JSON Feed',
-      }),
-      href: useBaseUrl('/blog/feed.json', { absolute: true }),
-    },
-  ];
-
-  return (
-    <BlogCard
-      title={translate({
-        id: 'blog.sidebar.feed.title',
-        message: 'Subscribe',
-      })}
-    >
-      <div className={styles.feedGrid}>
-        {feeds.map((feed) => (
-          <Link
-            key={feed.href}
-            href={feed.href}
-            aria-label={feed.ariaLabel}
-            className={styles.feedTile}
-          >
-            <Icon
-              icon={feed.icon}
-              width="1.2em"
-              height="1.2em"
-              className={styles.feedTileIcon}
-            />
-            <span className={styles.feedTileLabel}>{feed.name}</span>
-          </Link>
-        ))}
-      </div>
-    </BlogCard>
-  );
-}
-
 type Props = {
   title?: string;
   description?: string;
@@ -292,7 +256,6 @@ export default function BlogScaffold({
                 <CalendarCard />
                 <StatsCard />
                 <TagsCard />
-                <FeedCard />
               </>
             )}
           </>

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -101,11 +101,6 @@
   padding: 0.62rem 0.7rem;
   border-radius: 12px;
   border: 1px solid var(--ifm-color-emphasis-200);
-  transition: border-color 160ms ease;
-}
-
-.statTile:hover {
-  border-color: var(--ifm-color-primary);
 }
 
 .statHead {
@@ -268,7 +263,8 @@
 .feedGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.5rem;
+  gap: 0.55rem;
+  margin-top: 0.55rem;
 }
 
 .feedTile {


### PR DESCRIPTION
## Summary
- 侧栏：删除 Subscribe / Statistics 卡的标题；统计去掉访客/浏览两项；订阅 3 个磁贴并入统计卡第二行（独立的 FeedCard 删除）；统计磁贴去掉 hover 边框高亮
- Moments 页面：标题前加 sparkles 图标；右侧计数改为纯文本 "4 moments"，无任何容器
- 清理未用的 i18n 键和 useAnalytics import

## Test plan
- [x] /blog 侧栏 4 个卡片：作者 / 日历 / 统计(含订阅) / 热门标签
- [x] 统计卡上排 2 个数据磁贴 + 下排 3 个订阅磁贴，gap 一致
- [x] /blog/moments 标题左侧带主色 sparkles，右侧无容器纯文本计数

🤖 Generated with [Claude Code](https://claude.com/claude-code)