### PR TITLE
refactor: 删除两处真正多余的防御性代码

### DIFF
--- a/src/hooks/useAnimatedNumber.ts
+++ b/src/hooks/useAnimatedNumber.ts
@@ -17,11 +17,6 @@ export function useAnimatedNumber(
   useEffect(() => {
     if (target == null || !Number.isFinite(target)) return;
 
-    if (typeof window === 'undefined') {
-      setValue(target);
-      return;
-    }
-
     const from = fromRef.current;
     const delta = target - from;
     if (delta === 0) {

--- a/src/pages/insights/_components/UptimeSection.tsx
+++ b/src/pages/insights/_components/UptimeSection.tsx
@@ -16,12 +16,11 @@ function lastStatus(beats: KumaHeartbeat[] | undefined): number | undefined {
 function avgPing(beats: KumaHeartbeat[] | undefined): number | null {
   if (!beats || beats.length === 0) return null;
   const valid = beats.filter(
-    (b) => typeof b.ping === 'number' && Number.isFinite(b.ping)
+    (b): b is KumaHeartbeat & { ping: number } =>
+      typeof b.ping === 'number' && Number.isFinite(b.ping)
   );
   if (valid.length === 0) return null;
-  return Math.round(
-    valid.reduce((s, b) => s + (b.ping ?? 0), 0) / valid.length
-  );
+  return Math.round(valid.reduce((s, b) => s + b.ping, 0) / valid.length);
 }
 
 function MonitorRow({


### PR DESCRIPTION
## Summary

复核全仓后，确认仅有两处属于真正多余的防御性代码，本 PR 把它们删掉：

- `src/hooks/useAnimatedNumber.ts`：去掉 `useEffect` 内部的 `typeof window === 'undefined'` 分支。`useEffect` 在 SSG 阶段不会执行，这段是死代码。
- `src/pages/insights/_components/UptimeSection.tsx`：给 `avgPing` 的 `filter` 加上类型谓词，`reduce` 里的 `b.ping ?? 0` 因此不再需要——上一行已保证全是有限数。

讨论中我之前还点过几处（例如 `SysStatusCard.tsx` 的 `String(... ?? '')`、`about/_components.tsx` 的 `|| 1`、`HeartbeatBar` 的 `beats ?? []`），复核后发现要么必要要么属于设计选择，不在本 PR 范围。

## Test plan

- [x] `npm run check`（i18n + format + typecheck）通过
- [ ] 手动确认 `/insights` 页面 uptime 平均 ping 数值与改前一致
- [ ] 手动确认依赖 `useAnimatedNumber` 的数字动画在浏览器中表现正常

https://claude.ai/code/session_01J3i1pz5N5iDVTN5UQFgSDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3i1pz5N5iDVTN5UQFgSDz)_