### PR TITLE
refactor(css): 统一媒体查询为 max-width 写法

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ There is no test runner. `npm run check` is the gate.
 ## Architecture
 
 ### Content vs. code
+
 - `docs/` — three doc sets (`contest/`, `note/`, `project/`) wired up in `sidebars.ts` as `sidebar1/2/3`. Sidebars are hand-curated, not auto-generated.
 - `blog/` — MDX posts grouped by topic folders; `authors.yml` and `tags.yml` define the controlled vocabularies (`onInlineTags`/`onInlineAuthors` warn if a post uses an unlisted value).
 - `src/pages/` — custom React pages (`about`, `travel`, `friends`, `resources`, `settings`, `insights`, `changelog`, `privacy`, plus the bespoke `index.tsx` cover/home). Page-local React lives in `src/pages/_components/` (the leading `_` stops Docusaurus from routing it).
@@ -36,13 +37,17 @@ There is no test runner. `npm run check` is the gate.
 - `static/` — copied verbatim to site root. Contains `CNAME`, `.nojekyll`, verification files, and image/JSON assets.
 
 ### Build-time metadata
+
 `docusaurus.config.ts` shells out to `git` (wrapped in `safeGit`) to compute `BUILD_TIME`, `GIT_SHA`, `GIT_COUNT`, and a `DEBUG_ID` exposed via `customFields`. Don't break that fallback path — code must still build outside a git checkout.
 
 ### Markdown pipeline
+
 Docs, blog, and pages all share the same plugin set: `remark-math` + `rehype-katex` for LaTeX, `@docusaurus/remark-plugin-npm2yarn` (sync) for install snippets, Mermaid via `@docusaurus/theme-mermaid`, and live React via `@docusaurus/theme-live-codeblock`. Admonitions are extended with a custom `example` keyword.
 
 ### i18n (critical)
+
 The site ships in `en` (default) and `zh-Hans`.
+
 - Every user-facing string in code must use `translate({ id, message })` (or `<Translate>`) from `@docusaurus/Translate`. After adding/changing strings, run `npm run i18n` and add the Chinese counterpart to `i18n/zh-Hans/code.json`.
 - Translated content lives under `i18n/zh-Hans/`:
   - `docusaurus-plugin-content-docs/current.json` — sidebar/category labels
@@ -51,6 +56,7 @@ The site ships in `en` (default) and `zh-Hans`.
 - `onBrokenLinks: 'throw'` is set, so missing translated targets will fail the build.
 
 ### Styling
+
 Components use CSS Modules (`styles.module.css` next to `index.tsx`). Global tokens and overrides live in `src/css/custom.css`. Per the contributing guide, prefer modern CSS (`grid`, `clamp()`, `color-mix()`, container queries) over JS layout.
 
 ## Conventions (from `.github/CONTRIBUTING.md`)

--- a/blog/travel/places.mdx
+++ b/blog/travel/places.mdx
@@ -125,7 +125,7 @@ tags: [travel, resource]
 97. **Samarkand and Bukhara, Uzbekistan — 乌兹别克斯坦 撒马尔罕与布哈拉**
 98. **Terra Cotta Army, China — 中国 兵马俑**
 99. Taj Mahal, India — 印度 泰姬陵
-100. Vatican City — 梵蒂冈城
+100.  Vatican City — 梵蒂冈城
 
 ## 第 51 个终生之地（51st Place of a Lifetime）
 

--- a/src/components/laikit/Section/styles.module.css
+++ b/src/components/laikit/Section/styles.module.css
@@ -42,7 +42,7 @@
   max-width: 48rem;
   margin: 0;
   color: var(--ifm-color-emphasis-700);
-  font-size: 1.125rem;
+  font-size: 1.25rem;
   line-height: 1.625;
 }
 
@@ -51,8 +51,8 @@
   margin-right: auto;
 }
 
-@media (min-width: 1024px) {
+@media (max-width: 1023.98px) {
   .description {
-    font-size: 1.25rem;
+    font-size: 1.125rem;
   }
 }

--- a/src/pages/_components/Blog/styles.module.css
+++ b/src/pages/_components/Blog/styles.module.css
@@ -9,27 +9,29 @@
   max-width: 80rem;
   margin: 0 auto;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   padding: 4rem 1.25rem 2rem;
 }
 
 .layout {
   width: 100%;
-  max-width: 48rem;
+  max-width: 80rem;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   gap: 1.25rem;
   margin: 0 auto;
+  padding: 0 1.25rem;
 }
 
 .copy {
-  width: 100%;
+  width: 50%;
   max-width: 48rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+  padding-inline: 1.25rem 2.5rem;
 }
 
 .title {
@@ -38,7 +40,7 @@
   gap: 0.75rem;
   margin: 0 0 2rem;
   color: var(--ifm-font-color-base);
-  font-size: 1.875rem;
+  font-size: 2.25rem;
   font-weight: 700;
   line-height: 1.25;
 }
@@ -53,7 +55,7 @@
 }
 
 .posts {
-  width: 100%;
+  width: 50%;
 }
 
 .postsHeading {
@@ -61,7 +63,7 @@
   align-items: center;
   gap: 0.5rem;
   width: 100%;
-  margin: 1.25rem 0 0;
+  margin: 0;
   color: var(--ifm-color-emphasis-700);
   font-size: 0.875rem;
   font-weight: 700;
@@ -69,7 +71,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 1.5rem;
   margin: 2rem 0;
   text-align: left;
@@ -81,7 +83,7 @@
 }
 
 .gridItemHidden {
-  display: none;
+  display: block;
 }
 
 .emptyState {
@@ -148,41 +150,41 @@
   text-decoration: none;
 }
 
-@media (min-width: 768px) {
-  .title {
-    font-size: 2.25rem;
-  }
-
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .gridItemHidden {
-    display: block;
-  }
-}
-
-@media (min-width: 1024px) {
+@media (max-width: 1023.98px) {
   .sectionContent {
-    flex-direction: row;
+    flex-direction: column;
   }
 
   .layout {
-    max-width: 80rem;
-    flex-direction: row;
-    padding: 0 1.25rem;
+    max-width: 48rem;
+    flex-direction: column;
+    padding: 0;
   }
 
   .copy,
   .posts {
-    width: 50%;
+    width: 100%;
   }
 
   .copy {
-    padding-inline: 1.25rem 2.5rem;
+    padding-inline: 0;
   }
 
   .postsHeading {
-    margin-top: 0;
+    margin-top: 1.25rem;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .title {
+    font-size: 1.875rem;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gridItemHidden {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

- 把仓库中仅剩的 3 处 `min-width` 媒体查询全部反演为 `max-width`，让全站响应式断点风格统一为"桌面优先 + 小屏覆写"。
- 涉及 `src/components/laikit/Section/styles.module.css`（1 处）和 `src/pages/_components/Blog/styles.module.css`（2 处，分别对应 `768px` / `1024px` 两层渐进增强）。
- 默认值切换为大屏样式，小屏在 `@media (max-width: 1023.98px)` / `@media (max-width: 767.98px)` 中回退；`0.02px` 偏移采用 Bootstrap 风格，避免 `min-width: X` ↔ `max-width: X-1` 的 sub-pixel 间隙。
- `Blog` 中两个新 max-width 块作用的类不重叠（`1023.98px` 改 `.sectionContent / .layout / .copy / .posts / .postsHeading`，`767.98px` 改 `.title / .grid / .gridItemHidden`），级联无冲突。
- 总 `@media` 数维持 39，不新增也不丢失。

## Test plan

- [x] `grep "@media.*min-width"` 全仓库无残留
- [x] `npm run check`（i18n + prettier + tsc）通过
- [ ] `npm start` 手动核对：首页 Blog 区块在 ≥1024 / 768–1023 / <768 三档断点下布局与改前一致
- [ ] `npm start` 手动核对：使用 `Section` 描述文案的页面在 ≥1024 / <1024 字号一致


---
_Generated by [Claude Code](https://claude.ai/code/session_01MJsQuCPox2Zg2EijNqqtgH)_