### PR TITLE
feat(home): 傅里叶变换轨迹改为柳叶笔笔触

### DIFF
--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -211,7 +211,7 @@ export default function FourierTransformCanvas() {
     let animationId: number;
 
     const drawEpicycles = (): Point => {
-      const { primary, colors } = themeRef.current;
+      const { colors } = themeRef.current;
       let x = 0;
       let y = 0;
 
@@ -239,26 +239,124 @@ export default function FourierTransformCanvas() {
         ctx.stroke();
       }
 
-      ctx.fillStyle = primary;
-      ctx.beginPath();
-      ctx.arc(x, y, 3, 0, TWO_PI);
-      ctx.fill();
-
       return { x, y };
     };
 
-    const drawPath = (points: Point[], alpha = 1) => {
+    // Willow-leaf brush: bell-curve taper sin(π·t) along the *full* curve
+    // (offset shifts t when the slice no longer starts at 0, e.g. during erase).
+    // Three passes — wide+faint, mid, crisp — give a soft glow; dark mode
+    // uses 'lighter' so the halo blooms instead of stacking opaquely.
+    const drawWillowLeaf = (points: Point[], offset: number) => {
+      const total = state.fourierX.length;
+      if (points.length < 2 || total < 2) return;
+
+      const N = points.length;
+      const baseWidth = Math.max(2.5, canvasSize * 0.014);
+      const taper = new Float32Array(N);
+      const nx = new Float32Array(N);
+      const ny = new Float32Array(N);
+
+      for (let i = 0; i < N; i++) {
+        const t = (i + offset) / total;
+        const tc = t < 0 ? 0 : t > 1 ? 1 : t;
+        taper[i] = Math.pow(Math.sin(Math.PI * tc), 0.65);
+
+        let dx: number;
+        let dy: number;
+        if (i === 0) {
+          dx = points[1].x - points[0].x;
+          dy = points[1].y - points[0].y;
+        } else if (i === N - 1) {
+          dx = points[i].x - points[i - 1].x;
+          dy = points[i].y - points[i - 1].y;
+        } else {
+          dx = points[i + 1].x - points[i - 1].x;
+          dy = points[i + 1].y - points[i - 1].y;
+        }
+        const len = Math.hypot(dx, dy) || 1;
+        nx[i] = -dy / len;
+        ny[i] = dx / len;
+      }
+
+      const passes = isDark
+        ? [
+            { scale: 2.6, alpha: 0.1, comp: 'lighter' },
+            { scale: 1.5, alpha: 0.32, comp: 'lighter' },
+            { scale: 1.0, alpha: 1.0, comp: 'source-over' },
+          ]
+        : [
+            { scale: 1.8, alpha: 0.09, comp: 'source-over' },
+            { scale: 1.3, alpha: 0.22, comp: 'source-over' },
+            { scale: 1.0, alpha: 1.0, comp: 'source-over' },
+          ];
+
+      const primary = themeRef.current.primary;
+      for (const pass of passes) {
+        const w = baseWidth * pass.scale;
+        ctx.save();
+        ctx.globalCompositeOperation = pass.comp as GlobalCompositeOperation;
+        ctx.globalAlpha = pass.alpha;
+        ctx.fillStyle = primary;
+
+        ctx.beginPath();
+        const w0 = w * taper[0];
+        ctx.moveTo(points[0].x + nx[0] * w0, points[0].y + ny[0] * w0);
+        for (let i = 1; i < N; i++) {
+          const ww = w * taper[i];
+          ctx.lineTo(points[i].x + nx[i] * ww, points[i].y + ny[i] * ww);
+        }
+        for (let i = N - 1; i >= 0; i--) {
+          const ww = w * taper[i];
+          ctx.lineTo(points[i].x - nx[i] * ww, points[i].y - ny[i] * ww);
+        }
+        ctx.closePath();
+        ctx.fill();
+        ctx.restore();
+      }
+    };
+
+    const drawLiveStroke = (points: Point[]) => {
       if (points.length < 2) return;
+      ctx.save();
       ctx.strokeStyle = themeRef.current.primary;
-      ctx.globalAlpha = alpha;
-      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.lineWidth = Math.max(2.5, canvasSize * 0.014);
+      ctx.globalAlpha = 0.92;
+      if (isDark) {
+        ctx.shadowColor = themeRef.current.primary;
+        ctx.shadowBlur = 12;
+      }
       ctx.beginPath();
       ctx.moveTo(points[0].x, points[0].y);
       for (let i = 1; i < points.length; i++) {
         ctx.lineTo(points[i].x, points[i].y);
       }
       ctx.stroke();
+      ctx.restore();
+    };
+
+    const drawTip = (x: number, y: number) => {
+      const primary = themeRef.current.primary;
+      ctx.save();
+      if (isDark) ctx.globalCompositeOperation = 'lighter';
+      ctx.fillStyle = primary;
+
+      ctx.globalAlpha = isDark ? 0.18 : 0.1;
+      ctx.beginPath();
+      ctx.arc(x, y, canvasSize * 0.04, 0, TWO_PI);
+      ctx.fill();
+
+      ctx.globalAlpha = isDark ? 0.36 : 0.22;
+      ctx.beginPath();
+      ctx.arc(x, y, canvasSize * 0.022, 0, TWO_PI);
+      ctx.fill();
+
       ctx.globalAlpha = 1;
+      ctx.beginPath();
+      ctx.arc(x, y, Math.max(2, canvasSize * 0.008), 0, TWO_PI);
+      ctx.fill();
+      ctx.restore();
     };
 
     const render = () => {
@@ -276,15 +374,17 @@ export default function FourierTransformCanvas() {
       ctx.fill();
 
       if (state.currentState === STATE.DRAWING) {
-        drawPath(state.drawing, 0.8);
+        drawLiveStroke(state.drawing);
       } else if (
         state.currentState === STATE.PLAYING &&
         state.fourierX.length > 0
       ) {
         if (state.drawing.length > 1) {
+          ctx.save();
           ctx.strokeStyle = primary;
-          ctx.globalAlpha = 0.2;
+          ctx.globalAlpha = 0.16;
           ctx.lineWidth = 1;
+          ctx.setLineDash([3, 5]);
           ctx.beginPath();
           ctx.moveTo(state.drawing[0].x, state.drawing[0].y);
           for (let i = 1; i < state.drawing.length; i++) {
@@ -292,17 +392,18 @@ export default function FourierTransformCanvas() {
           }
           ctx.closePath();
           ctx.stroke();
-          ctx.globalAlpha = 1;
+          ctx.restore();
         }
 
         const v = drawEpicycles();
         if (state.phase === 'draw') {
           state.path.push(v);
-          drawPath(state.path);
+          drawWillowLeaf(state.path, 0);
         } else {
           state.eraseIndex++;
-          drawPath(state.path.slice(state.eraseIndex));
+          drawWillowLeaf(state.path.slice(state.eraseIndex), state.eraseIndex);
         }
+        drawTip(v.x, v.y);
 
         const dt = TWO_PI / state.fourierX.length;
         state.time += dt;


### PR DESCRIPTION
## Summary

把主页"Fourier Transform"交互组件里单像素细线的轨迹换成柳叶笔笔触，让本轮跑完一圈像在用毛笔挥写一片光丝叶。

### 视觉改动

- **柳叶锥度**：沿曲线全局位置 t 计算 `sin(π·t)^0.65` 钟形宽度，两端收尖、中段丰满。轨迹分上下两条边按切线法向偏移，构造闭合多边形填充，得到真正的"双向尖头"叶形。
- **三层晕染**：每帧用相同形状跑三趟（外晕 / 中晕 / 实芯），暗色模式下外两趟启用 `'lighter'` 合成，光晕叠加而不是简单覆盖；亮色模式仍用普通 alpha 合成避免画面发灰。
- **本轮端点光晕**：原 3px 实点升级为外晕 + 中晕 + 实芯三层圆，伴随主轨迹笔尖发光，跟随移动如同灯火。
- **目标曲线参考**：alpha 从 0.2 降至 0.16 并改为虚线，让位给主笔触。
- **用户实时绘制**：圆角线帽 + 暗色 shadowBlur，与主轨迹笔触质感呼应。

### 实现要点

- `drawWillowLeaf(points, offset)`：`offset` 用于擦除阶段，让锥度按曲线全局位置（而非切片本地位置）计算 —— 擦除过中点后切片起点天然变细，避免突兀切口。
- 切线用中央差分计算，端点退化为前向/后向差分。
- 所有尺寸（笔宽、晕染半径、笔尖大小）按 `canvasSize` 比例缩放，保持小屏到 500px 主屏一致观感。
- DFT 系数与心形默认形状未动；这是纯渲染层改动。

### 兼容与质量

- 没有新增字符串，无需 i18n 改动。
- `npm run check`（i18n + format + typecheck）通过。
- 复用现有的 `themeRef` 主题切换链路，未改动 `useEffect` 依赖与生命周期。

## Test plan

- [ ] 本地 `npm start`，主页观察播放循环：心形应以柳叶笔感成形，两端收尖、中段最粗
- [ ] 切换暗色 / 亮色模式，确认晕染与主色协调
- [ ] 自定义绘制（拖拽画一个简单图形）后，新形状也以柳叶笔笔触播放
- [ ] 绘制阶段 → 擦除阶段切换平滑，擦除从笔头收回时无明显断口
- [ ] 缩窄窗口让 canvas < 500px，笔宽与笔尖按比例缩放，无视觉割裂
- [ ] `npm run check` 通过

---
_Generated by [Claude Code](https://claude.ai/code/session_01Go1ZLqLVJrzpKj3UVyk3HT)_