### PR TITLE
feat(home): 傅里叶变换轨迹改为扁锋笔触正负空间效果

### DIFF
--- a/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
+++ b/src/pages/_components/FourierTransform/FourierTransformCanvas.tsx
@@ -242,98 +242,49 @@ export default function FourierTransformCanvas() {
       return { x, y };
     };
 
-    // Willow-leaf brush: bell-curve taper sin(π·t) along the *full* curve
-    // (offset shifts t when the slice no longer starts at 0, e.g. during erase).
-    // Three passes — wide+faint, mid, crisp — give a soft glow; dark mode
-    // uses 'lighter' so the halo blooms instead of stacking opaquely.
-    const drawWillowLeaf = (points: Point[], offset: number) => {
-      const total = state.fourierX.length;
-      if (points.length < 2 || total < 2) return;
+    // Calligraphic broad-nib stroke. Each curve segment becomes a parallelogram
+    // offset by ±nib/2 along a fixed angle: width perceived = nib · |sin θ|
+    // where θ is the angle between motion and the nib axis. When the curve runs
+    // parallel to the nib the parallelogram collapses, producing the negative-
+    // space gaps that define a 柳叶笔 willow-leaf stroke.
+    const drawCalligraphic = (points: Point[]) => {
+      if (points.length < 2) return;
 
-      const N = points.length;
-      const baseWidth = Math.max(2.5, canvasSize * 0.014);
-      const taper = new Float32Array(N);
-      const nx = new Float32Array(N);
-      const ny = new Float32Array(N);
+      const nibLen = Math.max(8, canvasSize * 0.028);
+      const nibAngle = -Math.PI / 4;
+      const cosA = Math.cos(nibAngle);
+      const sinA = Math.sin(nibAngle);
 
-      for (let i = 0; i < N; i++) {
-        const t = (i + offset) / total;
-        const tc = t < 0 ? 0 : t > 1 ? 1 : t;
-        taper[i] = Math.pow(Math.sin(Math.PI * tc), 0.65);
-
-        let dx: number;
-        let dy: number;
-        if (i === 0) {
-          dx = points[1].x - points[0].x;
-          dy = points[1].y - points[0].y;
-        } else if (i === N - 1) {
-          dx = points[i].x - points[i - 1].x;
-          dy = points[i].y - points[i - 1].y;
-        } else {
-          dx = points[i + 1].x - points[i - 1].x;
-          dy = points[i + 1].y - points[i - 1].y;
+      const tracePath = (fullLen: number) => {
+        const hx = cosA * fullLen * 0.5;
+        const hy = sinA * fullLen * 0.5;
+        ctx.beginPath();
+        for (let i = 0; i < points.length - 1; i++) {
+          const p1 = points[i];
+          const p2 = points[i + 1];
+          ctx.moveTo(p1.x + hx, p1.y + hy);
+          ctx.lineTo(p2.x + hx, p2.y + hy);
+          ctx.lineTo(p2.x - hx, p2.y - hy);
+          ctx.lineTo(p1.x - hx, p1.y - hy);
+          ctx.closePath();
         }
-        const len = Math.hypot(dx, dy) || 1;
-        nx[i] = -dy / len;
-        ny[i] = dx / len;
-      }
-
-      const passes = isDark
-        ? [
-            { scale: 2.6, alpha: 0.1, comp: 'lighter' },
-            { scale: 1.5, alpha: 0.32, comp: 'lighter' },
-            { scale: 1.0, alpha: 1.0, comp: 'source-over' },
-          ]
-        : [
-            { scale: 1.8, alpha: 0.09, comp: 'source-over' },
-            { scale: 1.3, alpha: 0.22, comp: 'source-over' },
-            { scale: 1.0, alpha: 1.0, comp: 'source-over' },
-          ];
+      };
 
       const primary = themeRef.current.primary;
-      for (const pass of passes) {
-        const w = baseWidth * pass.scale;
-        ctx.save();
-        ctx.globalCompositeOperation = pass.comp as GlobalCompositeOperation;
-        ctx.globalAlpha = pass.alpha;
-        ctx.fillStyle = primary;
 
-        ctx.beginPath();
-        const w0 = w * taper[0];
-        ctx.moveTo(points[0].x + nx[0] * w0, points[0].y + ny[0] * w0);
-        for (let i = 1; i < N; i++) {
-          const ww = w * taper[i];
-          ctx.lineTo(points[i].x + nx[i] * ww, points[i].y + ny[i] * ww);
-        }
-        for (let i = N - 1; i >= 0; i--) {
-          const ww = w * taper[i];
-          ctx.lineTo(points[i].x - nx[i] * ww, points[i].y - ny[i] * ww);
-        }
-        ctx.closePath();
-        ctx.fill();
-        ctx.restore();
-      }
-    };
-
-    const drawLiveStroke = (points: Point[]) => {
-      if (points.length < 2) return;
+      // Ink-bleed halo: same nib axis, longer length so gaps survive.
       ctx.save();
-      ctx.strokeStyle = themeRef.current.primary;
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-      ctx.lineWidth = Math.max(2.5, canvasSize * 0.014);
-      ctx.globalAlpha = 0.92;
-      if (isDark) {
-        ctx.shadowColor = themeRef.current.primary;
-        ctx.shadowBlur = 12;
-      }
-      ctx.beginPath();
-      ctx.moveTo(points[0].x, points[0].y);
-      for (let i = 1; i < points.length; i++) {
-        ctx.lineTo(points[i].x, points[i].y);
-      }
-      ctx.stroke();
+      ctx.globalAlpha = isDark ? 0.22 : 0.1;
+      if (isDark) ctx.globalCompositeOperation = 'lighter';
+      ctx.fillStyle = primary;
+      tracePath(nibLen * 1.45);
+      ctx.fill();
       ctx.restore();
+
+      // Crisp ink.
+      ctx.fillStyle = primary;
+      tracePath(nibLen);
+      ctx.fill();
     };
 
     const drawTip = (x: number, y: number) => {
@@ -374,7 +325,7 @@ export default function FourierTransformCanvas() {
       ctx.fill();
 
       if (state.currentState === STATE.DRAWING) {
-        drawLiveStroke(state.drawing);
+        drawCalligraphic(state.drawing);
       } else if (
         state.currentState === STATE.PLAYING &&
         state.fourierX.length > 0
@@ -398,10 +349,10 @@ export default function FourierTransformCanvas() {
         const v = drawEpicycles();
         if (state.phase === 'draw') {
           state.path.push(v);
-          drawWillowLeaf(state.path, 0);
+          drawCalligraphic(state.path);
         } else {
           state.eraseIndex++;
-          drawWillowLeaf(state.path.slice(state.eraseIndex), state.eraseIndex);
+          drawCalligraphic(state.path.slice(state.eraseIndex));
         }
         drawTip(v.x, v.y);
 


### PR DESCRIPTION
## Summary

上一版 PR #52 的"柳叶笔"改用了沿曲线全局位置的钟形锥度填充——本质还是粗细变化的实心带，没有负空间。本 PR 改为真正的扁锋（broad nib）扫掠：

- **固定 -π/4 笔锋角**：每段曲线扫成一个平行四边形（端点各自沿笔锋方向偏移 ±nib/2）。
- **正负空间天然成立**：感知宽度 = `nib · |sin θ|`，θ 为曲线方向与笔锋轴的夹角。曲线方向与笔锋平行时平行四边形塌缩到零，曲线被天然"切断"，形成贯穿全图的负空间；垂直时达到最大正空间宽度。
- **一笔出现节奏**：心形（默认形状）跑完一圈会出现"粗—细—断—粗"的书法节奏，这才是 柳叶笔 的视觉特征。

### 实现要点

- 单次 `beginPath()` 内堆叠全部段的平行四边形，再 `fill()` 一次，避免每段都触发 path commit。
- 同笔锋角度叠一层加长 1.45× 的低 alpha "墨晕"，保留所有负空间间隙的同时给笔触带轻微光晕；暗色模式启用 `'lighter'` 让墨晕更鲜亮。
- 去掉为上版锥度方案配套的 `drawLiveStroke`：用户拖拽实时绘制时也走同一条 `drawCalligraphic` 通道，预览即所见。
- 本轮端点的三层光晕、目标曲线的虚线参考不动。
- 净减 49 行（39 增 88 删），整体复杂度下降。

### 兼容与质量

- 无新增字符串，i18n 无变化。
- `npm run check`（i18n + format + typecheck）通过。
- 主题切换链路（`themeRef` + `colorMode` 依赖）保持原状。

## Test plan

- [ ] `npm start` 主页观察：默认心形跑完一圈应出现明显粗细变化和断口（负空间），非均匀实心带
- [ ] 切换暗色 / 亮色模式，墨晕协调，间隙在两个模式下都清晰可见
- [ ] 自己画一个简单形状（如圆形），观察 笔锋方向 决定的粗细分布——圆形上左下右四个对位点会出现最粗，左上右下两条对角附近变细甚至断开
- [ ] 绘制阶段→擦除阶段切换平滑
- [ ] canvas 缩窄到 < 500px，笔锋长度按比例缩放，节奏感保持
- [ ] `npm run check` 通过

---
_Generated by [Claude Code](https://claude.ai/code/session_01Go1ZLqLVJrzpKj3UVyk3HT)_