### PR TITLE
refactor(blog): 归档页年份选择器去掉 URL hash 同步

### DIFF
--- a/src/theme/BlogArchivePage/index.tsx
+++ b/src/theme/BlogArchivePage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTheme } from '@site/src/hooks/useTheme';
 import BlogArchivePageOriginal from '@theme-original/BlogArchivePage';
 import { translate } from '@docusaurus/Translate';
@@ -80,28 +80,7 @@ export default function BlogArchivePage(props: Props): React.ReactElement {
       .map(([year, count]) => ({ year, count }));
   }, [posts]);
 
-  const validYears = useMemo(() => new Set(years.map((y) => y.year)), [years]);
   const [activeYear, setActiveYear] = useState<number | null>(null);
-
-  useEffect(() => {
-    const sync = () => {
-      const raw = window.location.hash.slice(1);
-      const y = Number(raw);
-      setActiveYear(Number.isFinite(y) && validYears.has(y) ? y : null);
-    };
-    sync();
-    window.addEventListener('hashchange', sync);
-    return () => window.removeEventListener('hashchange', sync);
-  }, [validYears]);
-
-  const handleYearChange = (year: number | null) => {
-    const url =
-      year === null
-        ? window.location.pathname
-        : `${window.location.pathname}#${year}`;
-    window.history.replaceState(null, '', url);
-    setActiveYear(year);
-  };
 
   const filteredPosts = useMemo(
     () =>
@@ -116,7 +95,7 @@ export default function BlogArchivePage(props: Props): React.ReactElement {
       <YearSelector
         years={years}
         activeYear={activeYear}
-        onYearChange={handleYearChange}
+        onYearChange={setActiveYear}
       />
       <BlogArchiveList posts={filteredPosts} />
     </BlogScaffold>


### PR DESCRIPTION
## Summary

- 归档页 `BlogArchivePage` 的年份选择器统一为与资源页一致的纯 `useState` 模式
- 删除 `useEffect` + `hashchange` 监听、`history.replaceState` 写入、`validYears` 校验集合、`handleYearChange` 包装函数
- `onYearChange` 直接绑定到 `setActiveYear`

## 动机

之前点击年份会在 URL 末尾追加 `#2026`，但资源页同类筛选并不写 URL，行为不一致。同时原实现存在水合闪烁：SSR 输出全部年份的列表，客户端 `useEffect` 才读 hash 改成单年份，会有一瞬间的"全部 → 单年份"切换。

去掉 URL 同步后两个页面行为一致，代码减少 23 行（净 -21），消除上述闪烁。

## 取舍

放弃了"分享带年份的归档链接"这一能力。考虑到原实现用的是 `replaceState` 而非 `pushState`，浏览器前进/后退本来也无法在筛选间导航，"可分享"是它仅剩的优势；权衡后认为对齐资源页风格、消除闪烁更重要。

## Test plan

- [x] `npm run check` 通过（i18n / prettier / tsc 全部干净）
- [ ] dev server 验证年份切换不再改 URL，刷新后回到全部
- [ ] 老链接 `/blog/archive#2026` 打开后不报错（hash 被忽略，正常显示全部）

https://claude.ai/code/session_01VycsZ2uv18T3bhJGL28vFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01VycsZ2uv18T3bhJGL28vFf)_