### PR TITLE
refactor(insights): 运行快照轮询从 8s 改为 2s

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5029,9 +5029,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5044,9 +5041,6 @@
       "integrity": "sha512-6ky7R43VMjWwmx3Yx7Jl7faLBBMAgMDt+/bN35RgwjiPgsIByz65EwytUVuW9rikB43BGHvA/eqlnjLrUzNBqw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5061,9 +5055,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5076,9 +5067,6 @@
       "integrity": "sha512-CoK37hva4AmHGh3VCsQXmGr40L36m1/AdnN5LEjUX6kx5rEH7/1nEBN6Ii72pejqDVvk9anEROmPDiPw10tpFg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5568,9 +5556,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5586,9 +5571,6 @@
       "integrity": "sha512-omcqjoZP/b8D8PuczVoRwJieC6ibj7qIxTftNYokz4/aSmKFHvsd7nIFfPk5ZvtzncbH4AY7+Dkr/Lp2gWxYeA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5606,9 +5588,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5624,9 +5603,6 @@
       "integrity": "sha512-G3Aa4tVS/3OGZBkoNIwUF9F6RAy+Osb4GOlo62SinLmDiErz/ykmM7KH0wkz6l9kM8jJq1HyAM6atJTUEbBk7g==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5644,9 +5620,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5662,9 +5635,6 @@
       "integrity": "sha512-N4Ggahe/8SUbTX50P6EdhbW9YWcgbZVb52R4cq6MK+zsoMjRq7rGvV5ztA05QnbaCYqMYx8rTY7KAIA3Crdo4Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5810,9 +5780,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5828,9 +5795,6 @@
       "integrity": "sha512-iTrXjSeVwhHp+w7I5srCSpG9prebj+j/lmWalljNXGagTuVmtEWdH/EDvtSq1JfJyKQ6KRKyeB3Qg6yGHhjr+Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5848,9 +5812,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5866,9 +5827,6 @@
       "integrity": "sha512-zBavh0QnsvjM9QMPmtOqMaUGSLr5tdj2gxEx4xXzOXBFkUKKRA+qEfx6LdTzIbrqqtK5Xf6CPBPT9kzhDLuaCA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -5886,9 +5844,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5904,9 +5859,6 @@
       "integrity": "sha512-wRXdcS0eaYU1Pm15gNGmVM7fsJ/xCxy3BnfNH52MC/ObgCIzBcFl3Yjn6yr6nkqNtDZyEt8IlQFQno5zEEvIpw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -12682,9 +12634,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12704,9 +12653,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -12728,9 +12674,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -12750,9 +12693,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/src/hooks/useSysStatus.ts
+++ b/src/hooks/useSysStatus.ts
@@ -18,7 +18,7 @@ export interface SysStatus {
 }
 
 const ENDPOINT = 'https://lailai.one/api/sys';
-const POLL_MS = 8000;
+const POLL_MS = 2000;
 
 export function useSysStatus() {
   const [data, setData] = useState<SysStatus | null>(null);

--- a/src/pages/insights/_components/SysStatusCard.tsx
+++ b/src/pages/insights/_components/SysStatusCard.tsx
@@ -180,16 +180,16 @@ function SysStatusCardInner() {
         <Group
           cells={[
             { label: 'cpu', value: cpuStr, valueClassName: mutedIfNull(cpu) },
+            {
+              label: 'load',
+              value: loadStr,
+              valueClassName: mutedIfNull(load1),
+            },
             { label: 'mem', value: memStr, valueClassName: mutedIfNull(mem) },
             {
               label: 'swap',
               value: swapStr,
               valueClassName: mutedIfNull(swap),
-            },
-            {
-              label: 'load',
-              value: loadStr,
-              valueClassName: mutedIfNull(load1),
             },
             {
               label: 'disk',
@@ -200,35 +200,35 @@ function SysStatusCardInner() {
         />
         <Group
           cells={[
+            { label: 'ip', value: ipNode, valueClassName: mutedIfNull(ip) },
             {
               label: 'ping',
               value: pingStr,
               valueClassName: mutedIfNull(ping),
             },
-            { label: 'ip', value: ipNode, valueClassName: mutedIfNull(ip) },
-            { label: 'host', value: host },
             {
               label: 'uptime',
               value: uptimeStr,
               valueClassName: mutedIfNull(serverUptime),
             },
-            { label: 'browser', value: browser },
-          ]}
-        />
-        <Group
-          cells={[
             {
               label: 'last_deploy',
               value: lastDeployStr,
               valueClassName: mutedIfNull(lastDeploy),
             },
-            { label: 'build_time', value: formatBuildTime(buildTime) },
-            { label: 'debug_id', value: debugId },
             {
               label: 'tls_expires',
               value: tlsStr,
               valueClassName: mutedIfNull(tlsExpires),
             },
+          ]}
+        />
+        <Group
+          cells={[
+            { label: 'build_time', value: formatBuildTime(buildTime) },
+            { label: 'debug_id', value: debugId },
+            { label: 'host', value: host },
+            { label: 'browser', value: browser },
             { label: 'datetime', value: formatDateTime(now) },
           ]}
         />

--- a/src/pages/insights/_components/SysStatusCard.tsx
+++ b/src/pages/insights/_components/SysStatusCard.tsx
@@ -9,7 +9,7 @@ import metricListStyles from './MetricList.module.css';
 import styles from './SysStatusCard.module.css';
 
 const PING_TARGET = 'https://analytics.lailai.one/script.js';
-const PING_INTERVAL = 8000;
+const PING_INTERVAL = 2000;
 const TICK_INTERVAL = 1000;
 
 function detectBrowser(ua: string): string {


### PR DESCRIPTION
## Summary

- 将 `useSysStatus` 中 `/api/sys` 的轮询间隔 `POLL_MS` 从 `8000` 改为 `2000`
- 将 `SysStatusCard` 中客户端 ping 探测的 `PING_INTERVAL` 从 `8000` 改为 `2000`
- 让"洞察"页运行快照中实时变化的字段（cpu / mem / load / ping 等）更新更及时

## 取舍

由于 `cpu/mem/swap/load/disk/ip/uptime/last_deploy/tls_expires` 共用同一个 `/api/sys` 接口，无法在客户端按字段分别轮询，因此整个接口的 QPS 同步翻 4 倍。慢字段（disk、ip、uptime、tls_expires）在显示粒度上不会因此呈现差异，可接受。`datetime`（1s）与构建期注入的 `build_time` / `debug_id` 不受影响。

## Test plan

- [ ] `npm run check` 通过
- [ ] `npm start` 打开 `/insights`，观察"运行快照"中 cpu/mem/load/ping 数值约每 2 秒更新一次
- [ ] DevTools Network 面板确认 `/api/sys` 与 `analytics.lailai.one/script.js` 各自约每 2 秒一次

https://claude.ai/code/session_0119eWViAnTCt8EBYuNEExs3

---
_Generated by [Claude Code](https://claude.ai/code/session_0119eWViAnTCt8EBYuNEExs3)_