### PR TITLE
perf(insights): bump runtime snapshot polling to 1Hz

### DIFF
--- a/src/hooks/useSysStatus.ts
+++ b/src/hooks/useSysStatus.ts
@@ -18,7 +18,7 @@ export interface SysStatus {
 }
 
 const ENDPOINT = 'https://lailai.one/api/sys';
-const POLL_MS = 2000;
+const POLL_MS = 1000;
 
 export function useSysStatus() {
   const [data, setData] = useState<SysStatus | null>(null);

--- a/src/pages/insights/_components/SysStatusCard.tsx
+++ b/src/pages/insights/_components/SysStatusCard.tsx
@@ -9,7 +9,7 @@ import metricListStyles from './MetricList.module.css';
 import styles from './SysStatusCard.module.css';
 
 const PING_TARGET = 'https://analytics.lailai.one/script.js';
-const PING_INTERVAL = 2000;
+const PING_INTERVAL = 1000;
 const TICK_INTERVAL = 1000;
 
 function detectBrowser(ua: string): string {


### PR DESCRIPTION
## Summary
- 前端 `useSysStatus` 与 `SysStatusCard` 的轮询周期从 2s 降到 1s
- 配合后端 `/api/sys` 已经把采样周期改为 1s,并对 CPU 字段使用 2.5s 滑动窗口(0.1% 分度);Caddy 缓存头改为 `no-store`

## Test plan
- [x] `npm run check` 通过
- [x] 后端 `ts` 步进精确 1000ms,CPU 值步进为 0.1% 整数倍,冷启动 2.5s 内返回 `null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)