### PR TITLE
perf(insights): restore runtime snapshot polling to 2s

### DIFF
--- a/src/hooks/useSysStatus.ts
+++ b/src/hooks/useSysStatus.ts
@@ -18,7 +18,7 @@ export interface SysStatus {
 }
 
 const ENDPOINT = 'https://lailai.one/api/sys';
-const POLL_MS = 1000;
+const POLL_MS = 2000;
 
 export function useSysStatus() {
   const [data, setData] = useState<SysStatus | null>(null);

--- a/src/pages/insights/_components/SysStatusCard.tsx
+++ b/src/pages/insights/_components/SysStatusCard.tsx
@@ -9,7 +9,7 @@ import metricListStyles from './MetricList.module.css';
 import styles from './SysStatusCard.module.css';
 
 const PING_TARGET = 'https://analytics.lailai.one/script.js';
-const PING_INTERVAL = 1000;
+const PING_INTERVAL = 2000;
 const TICK_INTERVAL = 1000;
 
 function detectBrowser(ua: string): string {


### PR DESCRIPTION
## Summary
- 1Hz 节奏视觉上太跳,把前端 `POLL_MS` 与 `PING_INTERVAL` 改回 2000ms
- 后端 `/api/sys` 仍保留 1s 采样、CPU 2.5s 滑动窗口(0.1% 分度)与 `Cache-Control: no-store`,这些是真正有价值的改进,不动

## Test plan
- [x] `npm run check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)