### PR TITLE
CodeBlock: show byte size next to language

### DIFF
--- a/src/theme/CodeBlock/Layout/index.tsx
+++ b/src/theme/CodeBlock/Layout/index.tsx
@@ -7,12 +7,19 @@ import Content from '@theme/CodeBlock/Content';
 import Buttons from '@theme/CodeBlock/Buttons';
 import styles from './styles.module.css';
 
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 export default function CodeBlockLayout({
   className,
 }: {
   className?: string;
 }): React.ReactElement {
   const { metadata } = useCodeBlockContext();
+  const size = formatBytes(new TextEncoder().encode(metadata.code).length);
   return (
     <Container
       as="div"
@@ -27,8 +34,11 @@ export default function CodeBlockLayout({
         <div className={styles.title}>
           {metadata.title && <Title>{metadata.title}</Title>}
         </div>
-        <span className={styles.language}>
-          {metadata.language?.toLowerCase() ?? ''}
+        <span className={styles.meta}>
+          <span className={styles.size}>{size}</span>
+          <span className={styles.language}>
+            {metadata.language?.toLowerCase() ?? ''}
+          </span>
         </span>
       </div>
       <div className={styles.body}>

--- a/src/theme/CodeBlock/Layout/styles.module.css
+++ b/src/theme/CodeBlock/Layout/styles.module.css
@@ -63,10 +63,10 @@
   color: rgba(235, 235, 245, 0.6);
 }
 
-.language {
-  min-width: 52px;
+.meta {
+  align-items: baseline;
+  display: inline-flex;
   flex-shrink: 0;
-  text-align: right;
   font:
     500 12px -apple-system,
     BlinkMacSystemFont,
@@ -75,11 +75,19 @@
     sans-serif;
   letter-spacing: 0.01em;
   color: rgba(60, 60, 67, 0.55);
-  text-transform: lowercase;
   font-variant-numeric: tabular-nums;
 }
 
-[data-theme='dark'] .language {
+.size::after {
+  content: '·';
+  margin: 0 6px;
+}
+
+.language {
+  text-transform: lowercase;
+}
+
+[data-theme='dark'] .meta {
   color: rgba(235, 235, 245, 0.45);
 }
 


### PR DESCRIPTION
## Summary
- Add a UTF-8 byte-size label to the swizzled `CodeBlock/Layout` header, rendered before the language as `147 B · text`.
- Size is computed via `TextEncoder().encode(metadata.code).length` and formatted as `B / KB / MB`.
- Refactor header right column into a single `.meta` group so size and language share font/weight/color and read as one piece of metadata, separated by a middle dot.

## Why
Lets readers see at a glance how much code is in a block (especially useful for the prompt/snippets pages).

## Notes for reviewers
- No new user-facing strings introduced — units (`B`, `KB`, `MB`) are universal symbols, not translatable.
- No hover motion / decoration added; only color, weight, and a static separator.
- `npm run check` (i18n + format + typecheck) passes locally.
- Verified visually in the dev server (`npm start`).

## Test plan
- [ ] Open any docs page with code blocks (e.g. `/docs/project/lailai0916.github.io`) — header should show `<size> · <language>` aligned to the right.
- [ ] Confirm dark-mode color contrast looks right.
- [ ] Confirm long titles still ellipsize without overlapping the meta group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)