### PR TITLE
refactor(insights): Sunday-start weeks, tidy label styling

### DIFF
--- a/src/hooks/useUmamiPageviewsSeries.ts
+++ b/src/hooks/useUmamiPageviewsSeries.ts
@@ -62,8 +62,7 @@ function downsample(arr: SeriesPoint[], windowSize: number): SeriesPoint[] {
 
 function weekKey(iso: string): string {
   const d = new Date(iso.replace(' ', 'T'));
-  const offset = (d.getDay() + 6) % 7;
-  d.setDate(d.getDate() - offset);
+  d.setDate(d.getDate() - d.getDay());
   return bucketKey(d, 'day');
 }
 

--- a/src/pages/insights/_components/Sparkline.tsx
+++ b/src/pages/insights/_components/Sparkline.tsx
@@ -246,17 +246,6 @@ export default function Sparkline({
             className={styles.line}
           />
 
-          {hoverIdx === null && activePoint && (
-            <circle
-              cx={activePoint.x}
-              cy={activePoint.y}
-              r="4"
-              fill="var(--ifm-color-primary)"
-              stroke="var(--ifm-card-background-color)"
-              strokeWidth="2"
-            />
-          )}
-
           {hoverIdx !== null && activePoint && (
             <>
               <line

--- a/src/pages/insights/styles.module.css
+++ b/src/pages/insights/styles.module.css
@@ -30,8 +30,6 @@
 .heroLabel {
   font-size: 0.78rem;
   font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
   color: var(--ifm-color-emphasis-600);
 }
 

--- a/src/theme/BlogShared/styles.module.css
+++ b/src/theme/BlogShared/styles.module.css
@@ -125,8 +125,6 @@
   min-width: 0;
   font-size: 0.72rem;
   line-height: 1.2;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
   color: var(--ifm-color-emphasis-700);
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
## Summary

- **1-year chart aggregates by Sunday-start weeks.** `useUmamiPageviewsSeries.weekKey` previously offset to Monday (`(getDay+6)%7`); now snaps to Sunday via `d.getDate() - d.getDay()`. Verified in preview: tooltip now reads e.g. `Nov 9 – Nov 15, 2025` (Sun → Sat).
- **Removed the idle dot at the line's rightmost tip** in the Insights sparkline. The hover crosshair dot is unchanged.
- **Dropped `text-transform: uppercase` (and the paired `letter-spacing: 0.04em`) on `.heroLabel` and `.statLabel`.** Uppercase only affected Latin glyphs, leaving zh-Hans labels (e.g. 访客 / 浏览量) visually inconsistent with their en counterparts. Labels now render in their natural case in both locales.

## Test plan
- [x] `npm run check` passes (i18n + prettier + typecheck)
- [x] `/insights` → 1 year: x-axis ticks land on Sundays; hover tooltip range Sun → Sat
- [x] `/insights`: no dot at the rightmost line tip when not hovering; hover crosshair dot still appears
- [x] `/insights` and `/blog`: metric/stat labels render in natural case (not uppercase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)