### PR TITLE
refactor(Problem): redesign as macOS-style tabbed window

### DIFF
--- a/i18n/zh-Hans/code.json
+++ b/i18n/zh-Hans/code.json
@@ -140,14 +140,20 @@
   "components.neuralNetwork.description": {
     "message": "在下方绘制数字 0–9，神经网络会识别您的手写数字"
   },
-  "components.problem.code": {
-    "message": "代码（{num}）"
+  "components.problem.statement": {
+    "message": "题面"
   },
   "components.problem.solution": {
     "message": "题解"
   },
   "components.problem.error": {
     "message": "无法加载题目「{id}」。"
+  },
+  "components.problem.expand": {
+    "message": "展开"
+  },
+  "components.problem.collapse": {
+    "message": "收起"
   },
   "components.solution.luogu": {
     "message": "洛谷"

--- a/src/components/Problem/index.tsx
+++ b/src/components/Problem/index.tsx
@@ -1,11 +1,13 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
+import clsx from 'clsx';
 import Link from '@docusaurus/Link';
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import Details from '@theme/Details';
 import CodeBlock from '@theme/CodeBlock';
 import Admonition from '@theme/Admonition';
 import { translate } from '@docusaurus/Translate';
+import Card from '@site/src/components/laikit/Card';
+import { formatBytes } from '@site/src/utils/format';
+
+import styles from './styles.module.css';
 
 declare const require: any;
 type RawCodeModule = { default: string };
@@ -28,76 +30,108 @@ const ctx = require.context(
   /\.cpp$/
 ) as RawCodeContext;
 
-function GetCode({ id }: { id: string }) {
-  const formatTitle = (p: string) =>
-    p
-      .slice(p.lastIndexOf('/') + 1)
-      .replace(/\.cpp$/, '')
-      .replace(/_/g, ' ');
+type Tab =
+  | { kind: 'statement'; label: string; Render: React.ComponentType }
+  | { kind: 'solution'; label: string; Render: React.ComponentType }
+  | { kind: 'code'; label: string; code: string };
 
-  const codes = useMemo<Array<{ title: string; code: string }>>(() => {
-    return ctx
-      .keys()
-      .filter((p: string) => p.includes(`/${id}/`))
-      .map((p: string) => ({
-        title: formatTitle(p),
-        code: ctx(p).default,
-      }))
-      .sort(
-        (
-          a: { title: string; code: string },
-          b: { title: string; code: string }
-        ) => a.title.localeCompare(b.title)
-      );
-  }, [id]);
-
-  if (codes.length === 0) return <></>;
-
-  return (
-    <Details
-      summary={translate(
-        {
-          id: 'components.problem.code',
-          message: 'Code ({num})',
-        },
-        { num: codes.length }
-      )}
-    >
-      {codes.length === 1 ? (
-        <CodeBlock language="cpp">{codes[0].code}</CodeBlock>
-      ) : (
-        <Tabs>
-          {codes.map(({ title, code }) => (
-            <TabItem key={title} value={title}>
-              <CodeBlock language="cpp">{code}</CodeBlock>
-            </TabItem>
-          ))}
-        </Tabs>
-      )}
-    </Details>
-  );
+function formatCodeTitle(p: string): string {
+  return p
+    .slice(p.lastIndexOf('/') + 1)
+    .replace(/\.cpp$/, '')
+    .replace(/_/g, ' ');
 }
 
-function GetSolution({ id }: { id: string }) {
-  let mdxModule: { default: React.ComponentType };
-  try {
-    mdxModule = require(`@site/blog/solution/${id}.mdx`) as {
-      default: React.ComponentType;
-    };
-  } catch {
-    return <></>;
-  }
-  const { default: SOL } = mdxModule;
+function ProblemPanel({ tabs }: { tabs: Tab[] }) {
+  const [active, setActive] = useState<number | null>(0);
+  const lastIdx = useRef(0);
+  if (active !== null) lastIdx.current = active;
+  const open = active !== null;
+  const displayed = tabs[active ?? lastIdx.current];
+  const showMeta = open && displayed.kind === 'code';
 
   return (
-    <Details
-      summary={translate({
-        id: 'components.problem.solution',
-        message: 'Solution',
-      })}
-    >
-      {React.createElement(SOL)}
-    </Details>
+    <Card padding={0} className={clsx(styles.panel, open && styles.panelOpen)}>
+      <div className={styles.header}>
+        <div className={styles.dots} aria-hidden="true">
+          <span className={styles.dot} style={{ background: '#ff5f57' }} />
+          <span className={styles.dot} style={{ background: '#ffbd2e' }} />
+          <span className={styles.dot} style={{ background: '#28c840' }} />
+        </div>
+        <div className={styles.tabs} role="tablist">
+          {tabs.map((t, i) => (
+            <button
+              key={i}
+              type="button"
+              role="tab"
+              aria-selected={i === active}
+              className={clsx(styles.tab, i === active && styles.tabActive)}
+              onClick={() => setActive((cur) => (cur === i ? null : i))}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <div className={styles.right}>
+          {showMeta && displayed.kind === 'code' && (
+            <span className={styles.meta} aria-hidden="true">
+              <span className={styles.size}>
+                {formatBytes(new TextEncoder().encode(displayed.code).length)}
+              </span>
+              <span className={styles.language}>cpp</span>
+            </span>
+          )}
+          <button
+            type="button"
+            className={styles.toggle}
+            aria-expanded={open}
+            aria-label={
+              open
+                ? translate({
+                    id: 'components.problem.collapse',
+                    message: 'Collapse',
+                  })
+                : translate({
+                    id: 'components.problem.expand',
+                    message: 'Expand',
+                  })
+            }
+            onClick={() => setActive((cur) => (cur === null ? 0 : null))}
+          >
+            <svg
+              className={styles.chevron}
+              viewBox="0 0 20 20"
+              aria-hidden="true"
+            >
+              <path
+                d="M5 8l5 5 5-5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        className={clsx(styles.collapse, open && styles.collapseOpen)}
+        aria-hidden={!open}
+      >
+        <div className={styles.body} role="tabpanel">
+          {displayed.kind === 'code' ? (
+            <CodeBlock language="cpp" className="codeBlockBare">
+              {displayed.code}
+            </CodeBlock>
+          ) : (
+            <div className={styles.bodyInner}>
+              <displayed.Render />
+            </div>
+          )}
+        </div>
+      </div>
+    </Card>
   );
 }
 
@@ -123,14 +157,58 @@ export default function Problem({ id }: { id: string }) {
   const { default: MDX, frontMatter } = mdxModule;
   const { title = id, link } = frontMatter ?? {};
 
-  return (
-    <Admonition
-      type="example"
-      title={link ? <Link href={link}>{title}</Link> : title}
-    >
-      {React.createElement(MDX)}
-      <GetSolution id={id} />
-      <GetCode id={id} />
-    </Admonition>
-  );
+  const tabs = useMemo<Tab[]>(() => {
+    const list: Tab[] = [
+      {
+        kind: 'statement',
+        label: translate({
+          id: 'components.problem.statement',
+          message: 'Problem',
+        }),
+        Render: () => (
+          <>
+            <div className={styles.title}>
+              {link ? (
+                <Link href={link} className={styles.titleLink}>
+                  {title}
+                </Link>
+              ) : (
+                title
+              )}
+            </div>
+            <MDX />
+          </>
+        ),
+      },
+    ];
+
+    try {
+      const sol = require(`@site/blog/solution/${id}.mdx`) as {
+        default: React.ComponentType;
+      };
+      list.push({
+        kind: 'solution',
+        label: translate({
+          id: 'components.problem.solution',
+          message: 'Solution',
+        }),
+        Render: sol.default,
+      });
+    } catch {
+      // no solution available
+    }
+
+    const codes = ctx
+      .keys()
+      .filter((p) => p.includes(`/${id}/`))
+      .map((p) => ({ label: formatCodeTitle(p), code: ctx(p).default }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+    for (const c of codes) {
+      list.push({ kind: 'code', label: c.label, code: c.code });
+    }
+
+    return list;
+  }, [id, link, title, MDX]);
+
+  return <ProblemPanel tabs={tabs} />;
 }

--- a/src/components/Problem/styles.module.css
+++ b/src/components/Problem/styles.module.css
@@ -1,0 +1,224 @@
+.panel {
+  margin: 1.25rem 0;
+  overflow: hidden;
+}
+
+.title {
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  line-height: 1.45;
+  margin-bottom: 0.75rem;
+}
+
+.titleLink {
+  color: var(--ifm-color-content);
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.titleLink:hover {
+  color: var(--ifm-color-primary);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.header {
+  align-items: center;
+  background-color: var(--ifm-card-background-color);
+  background-image: linear-gradient(
+    rgba(246, 246, 247, 0.85),
+    rgba(246, 246, 247, 0.85)
+  );
+  backdrop-filter: saturate(180%) blur(20px);
+  -webkit-backdrop-filter: saturate(180%) blur(20px);
+  display: grid;
+  gap: 12px;
+  grid-template-columns: auto 1fr auto;
+  height: 42px;
+  padding: 0 1rem 0 1.25rem;
+}
+
+[data-theme='dark'] .header {
+  background-image: linear-gradient(
+    rgba(40, 40, 42, 0.85),
+    rgba(40, 40, 42, 0.85)
+  );
+}
+
+.dots {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.dot {
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.12);
+  display: inline-block;
+  height: 12px;
+  width: 12px;
+}
+
+.tabs {
+  align-items: center;
+  display: flex;
+  gap: 2px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.tab {
+  appearance: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: rgba(60, 60, 67, 0.7);
+  cursor: pointer;
+  flex-shrink: 0;
+  font:
+    500 13px -apple-system,
+    BlinkMacSystemFont,
+    'SF Pro Text',
+    'Segoe UI',
+    sans-serif;
+  letter-spacing: -0.01em;
+  max-width: 200px;
+  overflow: hidden;
+  padding: 4px 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .tab {
+  color: rgba(235, 235, 245, 0.6);
+}
+
+.tab:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+  color: var(--ifm-color-content);
+}
+
+[data-theme='dark'] .tab:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.tabActive,
+.tabActive:hover {
+  background-color: var(--ifm-card-background-color);
+  border-color: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-content);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+[data-theme='dark'] .tabActive,
+[data-theme='dark'] .tabActive:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+.right {
+  align-items: center;
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 10px;
+}
+
+.meta {
+  align-items: baseline;
+  color: rgba(60, 60, 67, 0.55);
+  display: inline-flex;
+  font:
+    500 12px -apple-system,
+    BlinkMacSystemFont,
+    'SF Pro Text',
+    'Segoe UI',
+    sans-serif;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+}
+
+[data-theme='dark'] .meta {
+  color: rgba(235, 235, 245, 0.45);
+}
+
+.size::after {
+  content: '·';
+  margin: 0 6px;
+}
+
+.language {
+  text-transform: lowercase;
+}
+
+.toggle {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: rgba(60, 60, 67, 0.55);
+  cursor: pointer;
+  display: inline-flex;
+  height: 28px;
+  justify-content: center;
+  padding: 0;
+  width: 28px;
+}
+
+[data-theme='dark'] .toggle {
+  color: rgba(235, 235, 245, 0.45);
+}
+
+.toggle:hover {
+  background-color: rgba(0, 0, 0, 0.04);
+  color: var(--ifm-color-content);
+}
+
+[data-theme='dark'] .toggle:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.chevron {
+  height: 16px;
+  transition: transform 0.2s ease;
+  width: 16px;
+}
+
+.panelOpen .chevron {
+  transform: rotate(180deg);
+}
+
+.collapse {
+  display: grid;
+  grid-template-rows: 0fr;
+  overflow: hidden;
+  transition: grid-template-rows 0.28s ease;
+}
+
+.collapseOpen {
+  grid-template-rows: 1fr;
+}
+
+.body {
+  background-color: var(--ifm-card-background-color);
+  min-height: 0;
+}
+
+.collapseOpen .body {
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.bodyInner {
+  padding: 16px;
+}
+
+.bodyInner > :last-child {
+  margin-bottom: 0;
+}

--- a/src/theme/CodeBlock/Layout/index.tsx
+++ b/src/theme/CodeBlock/Layout/index.tsx
@@ -5,13 +5,8 @@ import Container from '@theme/CodeBlock/Container';
 import Title from '@theme/CodeBlock/Title';
 import Content from '@theme/CodeBlock/Content';
 import Buttons from '@theme/CodeBlock/Buttons';
+import { formatBytes } from '@site/src/utils/format';
 import styles from './styles.module.css';
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 export default function CodeBlockLayout({
   className,
@@ -19,28 +14,31 @@ export default function CodeBlockLayout({
   className?: string;
 }): React.ReactElement {
   const { metadata } = useCodeBlockContext();
+  const bare = metadata.className?.split(/\s+/).includes('codeBlockBare');
   const size = formatBytes(new TextEncoder().encode(metadata.code).length);
   return (
     <Container
       as="div"
       className={clsx(className, metadata.className, styles.codeBlock)}
     >
-      <div className={styles.header}>
-        <div className={styles.dots}>
-          <span className={styles.dot} style={{ background: '#ff5f57' }} />
-          <span className={styles.dot} style={{ background: '#ffbd2e' }} />
-          <span className={styles.dot} style={{ background: '#28c840' }} />
-        </div>
-        <div className={styles.title}>
-          {metadata.title && <Title>{metadata.title}</Title>}
-        </div>
-        <span className={styles.meta}>
-          <span className={styles.size}>{size}</span>
-          <span className={styles.language}>
-            {metadata.language?.toLowerCase() ?? ''}
+      {!bare && (
+        <div className={styles.header}>
+          <div className={styles.dots}>
+            <span className={styles.dot} style={{ background: '#ff5f57' }} />
+            <span className={styles.dot} style={{ background: '#ffbd2e' }} />
+            <span className={styles.dot} style={{ background: '#28c840' }} />
+          </div>
+          <div className={styles.title}>
+            {metadata.title && <Title>{metadata.title}</Title>}
+          </div>
+          <span className={styles.meta}>
+            <span className={styles.size}>{size}</span>
+            <span className={styles.language}>
+              {metadata.language?.toLowerCase() ?? ''}
+            </span>
           </span>
-        </span>
-      </div>
+        </div>
+      )}
       <div className={styles.body}>
         <Content />
         <Buttons />

--- a/src/theme/CodeBlock/Layout/styles.module.css
+++ b/src/theme/CodeBlock/Layout/styles.module.css
@@ -99,3 +99,10 @@
   position: relative;
   direction: ltr;
 }
+
+:global(.codeBlockBare).codeBlock {
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  margin: 0;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -10,6 +10,19 @@ export function formatCompact(
   }).format(n);
 }
 
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  let n = bytes / 1024;
+  let unit = 'KB';
+  if (n >= 1024) {
+    n /= 1024;
+    unit = 'MB';
+  }
+  const formatted =
+    n >= 100 ? Math.round(n).toString() : n.toFixed(n >= 10 ? 1 : 2);
+  return `${formatted} ${unit}`;
+}
+
 export function formatBeijingDate(
   date: Date | string | number,
   locale: string = 'en-CA',


### PR DESCRIPTION
## Summary

Replace the `<Problem>` component's example-admonition wrapper with a single Card that mimics a macOS window. Traffic-light dots + Safari-style tabs sit at the top; the problem statement is the default-open first tab, followed by Solution (if any) and one tab per .cpp file in the problem folder.

## Why

The previous layout stacked an info-tinted admonition outside a separately bordered macOS code panel — two cards visually competing, plus the admonition's blue tint kept bleeding through. The icon and color band carried no problem-specific signal. This redesign makes the whole problem block a single coherent surface.

## What changed

- **`src/components/Problem`** — full rewrite. Outer is `laikit/Card` with `padding=0` and `overflow:hidden`; inner is the macOS strip with dots / tabs / meta·chevron. Tabs: `Problem` (statement MDX + linked title) | `Solution` (from `blog/solution/<id>.mdx`) | one per `.cpp` file. Default `active=0` (Problem tab open); clicking the active tab again collapses; chevron toggles `null ↔ 0`. Body collapse uses the `grid-template-rows: 0fr ↔ 1fr` trick + `overflow:hidden` on the grid container for a smooth 0.28 s height transition.
- **`src/theme/CodeBlock/Layout`** — recognize a magic `codeBlockBare` className: skip the inner macOS header and drop the outer border/radius/shadow so the bare code can be nested in the Problem panel without a duplicated chrome.
- **`src/utils/format.ts`** — extract `formatBytes`, used by both Problem and CodeBlock. Reformatted to 3 significant figures: `123 B`, `3.27 KB`, `12.6 KB`, `195 KB`, `9.87 MB`.
- **i18n** — drop orphan `components.problem.code`; add `components.problem.{statement,expand,collapse}` with zh-Hans translations.

## Test plan

- [x] `npm run check` (i18n + format + typecheck) clean
- [x] Single `.cpp` problem (P1981): Problem tab open by default; Solution absent; switching to `code` tab shows bare CodeBlock with no nested header
- [x] Multi `.cpp` problem (P3372): four tabs (`分块/三叉树/树状数组/线段树`), horizontally scrollable when overflow
- [x] Solution + code problem (P1366): three tabs total; Solution body has card-bg (no blue admonition tint bleed)
- [x] Default state: only Problem tab selected, others not highlighted; collapse/re-open behavior verified
- [x] Light + dark theme: active-tab contrast checked in both
- [x] Code size meta updates per active code tab; hidden when active tab is Problem/Solution