### PR TITLE
docs: rewrite note and project section intros

### DIFF
--- a/docs/note/index.mdx
+++ b/docs/note/index.mdx
@@ -2,7 +2,7 @@
 title: 笔记
 ---
 
-**笔记**（Note）板块记录了我在各学科学习过程中积累的笔记和总结，按数学（高中数学、大学数学）、英语（语法、语音、词汇）等专题分类，也零散收录了一些生活向的整理。
+**笔记**（Note）板块沉淀了我在日常学习中梳理过的知识和方法，既有数学、英语、语文等学科的概念笔记和备考整理，也散落着一些与设备、软件和生活方式有关的零碎记录。
 
 ![](https://cloud.lailai.one/f/4RZhK/header-note-light.svg#gh-light-mode-only)![](https://cloud.lailai.one/f/b3qs3/header-note-dark.svg#gh-dark-mode-only)
 

--- a/docs/project/index.mdx
+++ b/docs/project/index.mdx
@@ -9,7 +9,7 @@ import LorenzAttractor from '@site/src/components/playground/LorenzAttractor';
 import GameOfLife from '@site/src/components/playground/GameOfLife';
 import GitHubTrending from '@site/src/components/GitHubTrending';
 
-**项目**（Project）板块收录了我平时做过的一些项目和作品，按 AI 应用、Desmos 数学图形、终端工具、网页等类型分类，也整理了一些写作排版相关的指南。
+**项目**（Project）板块呈现了我设计与实现过的一些作品和实验，涵盖 AI 应用、Desmos 图形、终端工具、网页等不同方向的尝试，也附上一份关于写作、排版和编码风格的实践指南。
 
 ![](https://cloud.lailai.one/f/q01In/header-project-light.svg#gh-light-mode-only)![](https://cloud.lailai.one/f/ZwBfe/header-project-dark.svg#gh-dark-mode-only)
 


### PR DESCRIPTION
## Summary

- Rewrite the section intros at the top of [docs/note/index.mdx](docs/note/index.mdx) and [docs/project/index.mdx](docs/project/index.mdx).
- The contest intro (hand-written, kept as-is) had been used as an AI template for the other two, producing copies that stuck to the same skeleton — `...板块记录了...过程中积累的..., 按 X、Y、Z 分类，也整理了...`. Both rewrites swap that skeleton out while keeping a comparable length and structure.
- Drop parenthetical sub-categories like `数学（高中数学、大学数学）、英语（语法、语音、词汇）` so future maintenance doesn't have to keep the intro in lockstep with directory churn.

### Before / after

**笔记**
- before: 板块**记录了**我在各学科学习过程中积累的笔记和总结，**按**数学（高中数学、大学数学）、英语（语法、语音、词汇）等专题**分类**，**也**零散收录了一些生活向的整理。
- after: 板块**沉淀了**我在日常学习中梳理过的知识和方法，**既有**数学、英语、语文等学科的概念笔记和备考整理，**也散落着**一些与设备、软件和生活方式有关的零碎记录。

**项目**
- before: 板块**收录了**我平时做过的一些项目和作品，**按** AI 应用、Desmos 数学图形、终端工具、网页等类型**分类**，**也**整理了一些写作排版相关的指南。
- after: 板块**呈现了**我设计与实现过的一些作品和实验，**涵盖** AI 应用、Desmos 图形、终端工具、网页等不同方向的尝试，**也附上**一份关于写作、排版和编码风格的实践指南。

## Test plan

- [ ] `npm run check` passes locally
- [ ] Visual spot-check of `/docs/note` and `/docs/project` landing pages in dev (`npm start` / `npm run start:zh-Hans`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)